### PR TITLE
OneBotRequestEvent 的申请与拒绝支持可选的额外选项

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/request/OneBotRequestEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/request/OneBotRequestEventImpl.kt
@@ -17,6 +17,8 @@
 
 package love.forte.simbot.component.onebot.v11.core.event.internal.request
 
+import love.forte.simbot.ability.AcceptOption
+import love.forte.simbot.ability.RejectOption
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.UUID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
@@ -29,9 +31,7 @@ import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
-import love.forte.simbot.component.onebot.v11.core.event.request.OneBotFriendRequestEvent
-import love.forte.simbot.component.onebot.v11.core.event.request.OneBotGroupRequestEvent
-import love.forte.simbot.component.onebot.v11.core.event.request.OneBotRequestEvent
+import love.forte.simbot.component.onebot.v11.core.event.request.*
 import love.forte.simbot.component.onebot.v11.event.request.FriendRequestEvent
 import love.forte.simbot.component.onebot.v11.event.request.GroupRequestEvent
 
@@ -40,14 +40,23 @@ internal abstract class OneBotRequestEventImpl : OneBotRequestEvent {
     override val id: ID = UUID.random()
 
     override suspend fun accept() {
-        doSetRequest(true)
+        doAccept(emptyArray())
+    }
+
+    override suspend fun accept(vararg options: AcceptOption) {
+        doAccept(options)
     }
 
     override suspend fun reject() {
-        doSetRequest(false)
+        doReject(emptyArray())
     }
 
-    protected abstract suspend fun doSetRequest(approve: Boolean)
+    override suspend fun reject(vararg options: RejectOption) {
+        doReject(options)
+    }
+
+    protected abstract suspend fun doAccept(options: Array<out AcceptOption>)
+    protected abstract suspend fun doReject(options: Array<out RejectOption>)
 }
 
 internal class OneBotFriendRequestEventImpl(
@@ -55,10 +64,23 @@ internal class OneBotFriendRequestEventImpl(
     override val sourceEvent: FriendRequestEvent,
     override val bot: OneBotBot,
 ) : OneBotRequestEventImpl(), OneBotFriendRequestEvent {
-    override suspend fun doSetRequest(approve: Boolean) {
+    override suspend fun doAccept(options: Array<out AcceptOption>) {
+        val remark: String? = (
+            options.firstOrNull { it is OneBotFriendRequestAcceptOption.Remark }
+                as? OneBotFriendRequestAcceptOption.Remark
+            )?.remark
+
         SetFriendAddRequestApi.create(
             flag = sourceEvent.flag,
-            approve = approve,
+            approve = true,
+            remark = remark
+        ).requestDataBy(bot)
+    }
+
+    override suspend fun doReject(options: Array<out RejectOption>) {
+        SetFriendAddRequestApi.create(
+            flag = sourceEvent.flag,
+            approve = false,
         ).requestDataBy(bot)
     }
 
@@ -71,11 +93,25 @@ internal class OneBotGroupRequestEventImpl(
     override val sourceEvent: GroupRequestEvent,
     override val bot: OneBotBotImpl,
 ) : OneBotRequestEventImpl(), OneBotGroupRequestEvent {
-    override suspend fun doSetRequest(approve: Boolean) {
+    override suspend fun doAccept(options: Array<out AcceptOption>) {
         SetGroupAddRequestApi.create(
             flag = sourceEvent.flag,
             subType = sourceEvent.subType,
-            approve = approve
+            approve = true
+        ).requestDataBy(bot)
+    }
+
+    override suspend fun doReject(options: Array<out RejectOption>) {
+        val reason = (
+            options.firstOrNull { it is OneBotGroupRequestRejectOption.Reason }
+                as? OneBotGroupRequestRejectOption.Reason
+            )?.reason
+
+        SetGroupAddRequestApi.create(
+            flag = sourceEvent.flag,
+            subType = sourceEvent.subType,
+            approve = false,
+            reason = reason
         ).requestDataBy(bot)
     }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent.kt
@@ -17,6 +17,8 @@
 
 package love.forte.simbot.component.onebot.v11.core.event.request
 
+import love.forte.simbot.ability.AcceptOption
+import love.forte.simbot.ability.RejectOption
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotStranger
@@ -26,6 +28,8 @@ import love.forte.simbot.component.onebot.v11.event.request.GroupRequestEvent
 import love.forte.simbot.event.OrganizationJoinRequestEvent
 import love.forte.simbot.event.RequestEvent
 import love.forte.simbot.suspendrunner.STP
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.JvmSynthetic
 
 public typealias OBSourceRequestEvent = love.forte.simbot.component.onebot.v11.event.request.RequestEvent
 
@@ -41,6 +45,30 @@ public typealias OBSourceRequestEvent = love.forte.simbot.component.onebot.v11.e
  */
 public interface OneBotRequestEvent : OneBotBotEvent, RequestEvent {
     override val sourceEvent: OBSourceRequestEvent
+
+    /**
+     * 接受请求
+     */
+    @JvmSynthetic
+    override suspend fun accept()
+
+    /**
+     * 接受请求
+     */
+    @JvmSynthetic
+    override suspend fun accept(vararg options: AcceptOption)
+
+    /**
+     * 拒绝请求
+     */
+    @JvmSynthetic
+    override suspend fun reject()
+
+    /**
+     * 拒绝请求
+     */
+    @JvmSynthetic
+    override suspend fun reject(vararg options: RejectOption)
 }
 
 /**
@@ -79,7 +107,40 @@ public interface OneBotFriendRequestEvent : OneBotRequestEvent {
      */
     public val requesterId: LongID
         get() = sourceEvent.userId
+
+    /**
+     * 接受申请。
+     *
+     * @param options 好友申请中可使用的额外属性，
+     * 支持 [OneBotFriendRequestAcceptOption] 下的类型。
+     *
+     * @see OneBotFriendRequestAcceptOption
+     */
+    @JvmSynthetic
+    override suspend fun accept(vararg options: AcceptOption)
 }
+
+
+/**
+ * 可使用于 [OneBotFriendRequestEvent.accept] 中的额外属性 [AcceptOption] 实现。
+ */
+public sealed class OneBotFriendRequestAcceptOption : AcceptOption {
+    /**
+     * 接受申请后为其设置一个备注
+     */
+    public data class Remark(val remark: String) : OneBotFriendRequestAcceptOption()
+
+
+    public companion object {
+        /**
+         * 接受申请后为其设置一个备注
+         * @see Remark
+         */
+        @JvmStatic
+        public fun remark(remark: String): Remark = Remark(remark)
+    }
+}
+
 
 /**
  * 群添加申请事件
@@ -135,4 +196,37 @@ public interface OneBotGroupRequestEvent : OneBotRequestEvent, OrganizationJoinR
      */
     @STP
     override suspend fun requester(): OneBotStranger
+
+    /**
+     * 拒绝申请。
+     *
+     * @param options 拒绝时可提供的额外选项。
+     * 支持使用 [OneBotGroupRequestRejectOption] 下的类型。
+     *
+     * @see OneBotGroupRequestRejectOption
+     */
+    @JvmSynthetic
+    override suspend fun reject(vararg options: RejectOption)
+
+}
+
+
+/**
+ * 可使用于 [OneBotGroupRequestEvent.reject] 中的额外属性 [RejectOption] 实现。
+ */
+public sealed class OneBotGroupRequestRejectOption : RejectOption {
+    /**
+     * 拒绝的理由
+     */
+    public data class Reason(val reason: String) : OneBotGroupRequestRejectOption()
+
+    public companion object {
+        /**
+         * 拒绝的理由
+         *
+         * @see Reason
+         */
+        @JvmStatic
+        public fun reason(reason: String): Reason = Reason(reason)
+    }
 }


### PR DESCRIPTION
例如好友申请时：

```kotlin
request.accept(
  OneBotFriendRequestAcceptOption.remark("备注")
)
```

群申请时：

```kotlin
request.reject(
  OneBotGroupRequestRejectOption.reason("拒绝原因")
)
```