### PR TITLE
部分群消息事件实现中，获取 content 将直接查询API

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotGroupImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotGroupImpl.kt
@@ -32,7 +32,6 @@ import love.forte.simbot.component.onebot.v11.core.bot.requestResultBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupTextMsgApi
-import love.forte.simbot.component.onebot.v11.event.message.GroupMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
 import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
@@ -146,40 +145,6 @@ internal abstract class OneBotGroupImpl : OneBotGroup {
 
     override fun toString(): String = "OneBotGroup(id=$id, bot=${bot.id})"
 }
-
-internal class OneBotGroupEventImpl(
-    private val source: GroupMessageEvent,
-    override val bot: OneBotBotImpl,
-
-    /**
-     * 群名称
-     */
-    override val name: String,
-
-    /**
-     * 群主ID
-     */
-    override val ownerId: ID?
-) : OneBotGroupImpl() {
-    override val coroutineContext: CoroutineContext = bot.subContext
-
-    override val id: ID
-        get() = source.groupId
-}
-
-// TODO 群名称, 可能需要使用缓存或API初始化,
-//  事件中似乎取不到
-internal fun GroupMessageEvent.toGroup(
-    bot: OneBotBotImpl,
-    name: String = "",
-    ownerId: ID? = null
-): OneBotGroupEventImpl =
-    OneBotGroupEventImpl(
-        source = this,
-        bot = bot,
-        name = name,
-        ownerId = ownerId,
-    )
 
 /**
  * 通过API查询得到的群信息。

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
@@ -21,7 +21,6 @@ import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.core.actor.internal.toGroup
 import love.forte.simbot.component.onebot.v11.core.actor.internal.toMember
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
@@ -59,7 +58,8 @@ internal abstract class OneBotGroupMessageEventImpl(
     )
 
     override suspend fun content(): OneBotGroup {
-        return sourceEvent.toGroup(bot)
+        return bot.groupRelation.group(sourceEvent.groupId)
+            ?: error("Group with id $groupId is not found")
     }
 
     override suspend fun reply(text: String): OneBotMessageReceipt {

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
@@ -112,7 +112,7 @@ internal class OneBotGroupPrivateMessageEventImpl(
 
     override suspend fun source(): OneBotGroup {
         // TODO 额，怎么知道群号？
-        throw UnsupportedOperationException("The way to get the group number from PrivateMessageEvent is unknown.")
+        throw UnsupportedOperationException("The way to get the group id from PrivateMessageEvent is unknown yet.")
     }
 
     override fun toString(): String =


### PR DESCRIPTION
这可以解决群消息事件中无法从 content 中得到群名称的问题，缺点是有可能会造成额外的/没必要的API请求。
