### PR TITLE
所有原始事件类型均更名增加前缀 `Raw`

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -41,7 +41,7 @@ object P {
         override val homepage: String get() = HOMEPAGE
 
 
-        private val baseVersion = v(0, 2, 0)
+        private val baseVersion = v(0, 3, 0)
 
         val snapshotVersion = baseVersion - Version.SNAPSHOT
         override val version = if (isSnapshot()) snapshotVersion else baseVersion

--- a/internal-processors/event-type-resolver-processor/src/main/kotlin/onebot11/internal/processors/eventtyperesolver/EventTypeResolverProcessor.kt
+++ b/internal-processors/event-type-resolver-processor/src/main/kotlin/onebot11/internal/processors/eventtyperesolver/EventTypeResolverProcessor.kt
@@ -60,7 +60,7 @@ private val KSerializerClassName =
 private const val EVENT_BASE_PACKAGE = "love.forte.simbot.component.onebot.v11.event"
 
 private val EventClassName =
-    ClassName(EVENT_BASE_PACKAGE, "Event")
+    ClassName(EVENT_BASE_PACKAGE, "RawEvent")
 
 private val ExpectEventTypeAnnotationClassName =
     ClassName(EVENT_BASE_PACKAGE, "ExpectEventType")

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotFriendImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotFriendImpl.kt
@@ -26,7 +26,7 @@ import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateTextMsgApi
-import love.forte.simbot.component.onebot.v11.event.message.PrivateMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
 import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
@@ -73,11 +73,11 @@ internal abstract class OneBotFriendImpl : OneBotFriend {
 }
 
 /**
- * 基于 [PrivateMessageEvent.Sender] 的 [OneBotFriend] 实现
+ * 基于 [RawPrivateMessageEvent.Sender] 的 [OneBotFriend] 实现
  *
  */
 internal class OneBotFriendEventSenderImpl(
-    private val sender: PrivateMessageEvent.Sender,
+    private val sender: RawPrivateMessageEvent.Sender,
     override val bot: OneBotBotImpl,
 ) : OneBotFriendImpl(), OneBotFriend {
     override val coroutineContext: CoroutineContext = bot.subContext
@@ -89,7 +89,7 @@ internal class OneBotFriendEventSenderImpl(
         get() = sender.nickname
 }
 
-internal fun PrivateMessageEvent.Sender.toFriend(bot: OneBotBotImpl): OneBotFriendEventSenderImpl =
+internal fun RawPrivateMessageEvent.Sender.toFriend(bot: OneBotBotImpl): OneBotFriendEventSenderImpl =
     OneBotFriendEventSenderImpl(this, bot)
 
 internal class OneBotFriendApiResultImpl(

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotMemberImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotMemberImpl.kt
@@ -33,8 +33,8 @@ import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateTextMsgApi
-import love.forte.simbot.component.onebot.v11.event.message.GroupMessageEvent
-import love.forte.simbot.component.onebot.v11.event.message.PrivateMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
 import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
@@ -172,7 +172,7 @@ internal abstract class OneBotMemberImpl : OneBotMember {
 }
 
 internal class OneBotMemberPrivateMessageEventSenderImpl(
-    private val source: PrivateMessageEvent.Sender,
+    private val source: RawPrivateMessageEvent.Sender,
     override val groupId: ID?,
     override val bot: OneBotBotImpl,
     override val nick: String?,
@@ -188,9 +188,9 @@ internal class OneBotMemberPrivateMessageEventSenderImpl(
 }
 
 internal class OneBotMemberGroupMessageEventSenderImpl(
-    private val source: GroupMessageEvent.Sender,
+    private val source: RawGroupMessageEvent.Sender,
     override val groupId: ID?,
-    private val anonymous: GroupMessageEvent.Anonymous?,
+    private val anonymous: RawGroupMessageEvent.Anonymous?,
     override val bot: OneBotBotImpl,
 ) : OneBotMemberImpl() {
     override val coroutineContext: CoroutineContext = bot.subContext
@@ -224,7 +224,7 @@ internal class OneBotMemberGroupMessageEventSenderImpl(
     }
 }
 
-internal fun PrivateMessageEvent.Sender.toMember(
+internal fun RawPrivateMessageEvent.Sender.toMember(
     bot: OneBotBotImpl,
     groupId: ID? = null,
     nick: String? = null,
@@ -238,10 +238,10 @@ internal fun PrivateMessageEvent.Sender.toMember(
         role = role
     )
 
-internal fun GroupMessageEvent.Sender.toMember(
+internal fun RawGroupMessageEvent.Sender.toMember(
     bot: OneBotBotImpl,
     groupId: ID,
-    anonymous: GroupMessageEvent.Anonymous?
+    anonymous: RawGroupMessageEvent.Anonymous?
 ): OneBotMemberGroupMessageEventSenderImpl =
     OneBotMemberGroupMessageEventSenderImpl(
         source = this,

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
@@ -101,21 +101,21 @@ import love.forte.simbot.component.onebot.v11.core.event.internal.request.OneBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.stage.OneBotBotStartedEventImpl
 import love.forte.simbot.component.onebot.v11.core.utils.onEachErrorLog
 import love.forte.simbot.component.onebot.v11.event.UnknownEvent
-import love.forte.simbot.component.onebot.v11.event.message.GroupMessageEvent
-import love.forte.simbot.component.onebot.v11.event.message.PrivateMessageEvent
-import love.forte.simbot.component.onebot.v11.event.meta.HeartbeatEvent
-import love.forte.simbot.component.onebot.v11.event.meta.LifecycleEvent
-import love.forte.simbot.component.onebot.v11.event.notice.FriendAddEvent
-import love.forte.simbot.component.onebot.v11.event.notice.FriendRecallEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupAdminEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupBanEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupDecreaseEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupIncreaseEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupRecallEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupUploadEvent
-import love.forte.simbot.component.onebot.v11.event.notice.NotifyEvent
-import love.forte.simbot.component.onebot.v11.event.request.FriendRequestEvent
-import love.forte.simbot.component.onebot.v11.event.request.GroupRequestEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawHeartbeatEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawLifecycleEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawFriendAddEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawFriendRecallEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupAdminEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupBanEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupDecreaseEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupIncreaseEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupRecallEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupUploadEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawNotifyEvent
+import love.forte.simbot.component.onebot.v11.event.request.RawFriendRequestEvent
+import love.forte.simbot.component.onebot.v11.event.request.RawGroupRequestEvent
 import love.forte.simbot.component.onebot.v11.event.resolveEventSerializer
 import love.forte.simbot.component.onebot.v11.event.resolveEventSubTypeFieldName
 import love.forte.simbot.event.Event
@@ -126,7 +126,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.math.max
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import love.forte.simbot.component.onebot.v11.event.Event as OBRawEvent
+import love.forte.simbot.component.onebot.v11.event.RawEvent as OBRawEvent
 
 
 /**
@@ -597,25 +597,25 @@ internal fun OneBotBotImpl.resolveRawEventToEvent(raw: String, event: OBRawEvent
     return when (event) {
         //region 消息事件
         // 群消息、匿名消息、系统消息
-        is GroupMessageEvent -> when (event.subType) {
-            GroupMessageEvent.SUB_TYPE_NORMAL ->
+        is RawGroupMessageEvent -> when (event.subType) {
+            RawGroupMessageEvent.SUB_TYPE_NORMAL ->
                 OneBotNormalGroupMessageEventImpl(raw, event, bot)
 
-            GroupMessageEvent.SUB_TYPE_ANONYMOUS ->
+            RawGroupMessageEvent.SUB_TYPE_ANONYMOUS ->
                 OneBotAnonymousGroupMessageEventImpl(raw, event, bot)
 
-            GroupMessageEvent.SUB_TYPE_NOTICE ->
+            RawGroupMessageEvent.SUB_TYPE_NOTICE ->
                 OneBotNoticeGroupMessageEventImpl(raw, event, bot)
 
             else -> OneBotDefaultGroupMessageEventImpl(raw, event, bot)
         }
 
         // 好友私聊消息、成员临时会话
-        is PrivateMessageEvent -> when (event.subType) {
-            PrivateMessageEvent.SUB_TYPE_FRIEND ->
+        is RawPrivateMessageEvent -> when (event.subType) {
+            RawPrivateMessageEvent.SUB_TYPE_FRIEND ->
                 OneBotFriendMessageEventImpl(raw, event, bot)
 
-            PrivateMessageEvent.SUB_TYPE_GROUP ->
+            RawPrivateMessageEvent.SUB_TYPE_GROUP ->
                 OneBotGroupPrivateMessageEventImpl(raw, event, bot)
 
             else -> OneBotDefaultPrivateMessageEventImpl(raw, event, bot)
@@ -623,28 +623,28 @@ internal fun OneBotBotImpl.resolveRawEventToEvent(raw: String, event: OBRawEvent
         //endregion
 
         //region 元事件
-        is LifecycleEvent -> OneBotLifecycleEventImpl(raw, event, bot,)
-        is HeartbeatEvent -> OneBotHeartbeatEventImpl(raw, event, bot,)
+        is RawLifecycleEvent -> OneBotLifecycleEventImpl(raw, event, bot,)
+        is RawHeartbeatEvent -> OneBotHeartbeatEventImpl(raw, event, bot,)
         //endregion
 
         //region 申请事件
-        is FriendRequestEvent -> OneBotFriendRequestEventImpl(raw, event, bot)
-        is GroupRequestEvent -> OneBotGroupRequestEventImpl(raw, event, bot)
+        is RawFriendRequestEvent -> OneBotFriendRequestEventImpl(raw, event, bot)
+        is RawGroupRequestEvent -> OneBotGroupRequestEventImpl(raw, event, bot)
         //endregion
 
         //region notice events
-        is FriendAddEvent -> OneBotFriendAddEventImpl(raw, event, bot)
-        is FriendRecallEvent -> OneBotFriendRecallEventImpl(raw, event, bot)
-        is GroupAdminEvent -> OneBotGroupAdminEventImpl(raw, event, bot)
-        is GroupBanEvent -> OneBotGroupBanEventImpl(raw, event, bot)
-        is GroupIncreaseEvent -> OneBotGroupMemberIncreaseEventImpl(raw, event, bot)
-        is GroupDecreaseEvent -> OneBotGroupMemberDecreaseEventImpl(raw, event, bot)
-        is GroupRecallEvent -> OneBotGroupRecallEventImpl(raw, event, bot)
-        is GroupUploadEvent -> OneBotGroupUploadEventImpl(raw, event, bot)
-        is NotifyEvent -> when (event.subType) {
-            NotifyEvent.SUB_TYPE_HONOR -> OneBotHonorEventImpl(raw, event, bot)
-            NotifyEvent.SUB_TYPE_LUCKY_KING -> OneBotLuckyKingEventImpl(raw, event, bot)
-            NotifyEvent.SUB_TYPE_POKE -> when {
+        is RawFriendAddEvent -> OneBotFriendAddEventImpl(raw, event, bot)
+        is RawFriendRecallEvent -> OneBotFriendRecallEventImpl(raw, event, bot)
+        is RawGroupAdminEvent -> OneBotGroupAdminEventImpl(raw, event, bot)
+        is RawGroupBanEvent -> OneBotGroupBanEventImpl(raw, event, bot)
+        is RawGroupIncreaseEvent -> OneBotGroupMemberIncreaseEventImpl(raw, event, bot)
+        is RawGroupDecreaseEvent -> OneBotGroupMemberDecreaseEventImpl(raw, event, bot)
+        is RawGroupRecallEvent -> OneBotGroupRecallEventImpl(raw, event, bot)
+        is RawGroupUploadEvent -> OneBotGroupUploadEventImpl(raw, event, bot)
+        is RawNotifyEvent -> when (event.subType) {
+            RawNotifyEvent.SUB_TYPE_HONOR -> OneBotHonorEventImpl(raw, event, bot)
+            RawNotifyEvent.SUB_TYPE_LUCKY_KING -> OneBotLuckyKingEventImpl(raw, event, bot)
+            RawNotifyEvent.SUB_TYPE_POKE -> when {
                 event.selfId.value == event.targetId?.value ->
                     OneBotBotSelfPokeEventImpl(raw, event, bot)
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/OneBotEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/OneBotEvent.kt
@@ -29,7 +29,7 @@ import love.forte.simbot.event.Event
 /**
  * OneBot11原始事件结构体类型。
  */
-public typealias OBSourceEvent = love.forte.simbot.component.onebot.v11.event.Event
+public typealias OBSourceEvent = love.forte.simbot.component.onebot.v11.event.RawEvent
 
 /**
  * 一个OneBot组件事件基类。

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
@@ -33,7 +33,7 @@ import love.forte.simbot.component.onebot.v11.core.internal.message.OneBotMessag
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupTextMsgApi
-import love.forte.simbot.component.onebot.v11.event.message.GroupMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
 import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
@@ -41,7 +41,7 @@ import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 
 internal abstract class OneBotGroupMessageEventImpl(
-    sourceEvent: GroupMessageEvent,
+    sourceEvent: RawGroupMessageEvent,
     final override val bot: OneBotBotImpl
 ) : OneBotGroupMessageEvent {
 
@@ -95,7 +95,7 @@ internal abstract class OneBotGroupMessageEventImpl(
 
 internal class OneBotNormalGroupMessageEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupMessageEvent,
+    override val sourceEvent: RawGroupMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotGroupMessageEventImpl(sourceEvent, bot),
     OneBotNormalGroupMessageEvent {
@@ -109,7 +109,7 @@ internal class OneBotNormalGroupMessageEventImpl(
 
 internal class OneBotAnonymousGroupMessageEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupMessageEvent,
+    override val sourceEvent: RawGroupMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotGroupMessageEventImpl(sourceEvent, bot),
     OneBotAnonymousGroupMessageEvent {
@@ -122,7 +122,7 @@ internal class OneBotAnonymousGroupMessageEventImpl(
 
 internal class OneBotNoticeGroupMessageEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupMessageEvent,
+    override val sourceEvent: RawGroupMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotGroupMessageEventImpl(sourceEvent, bot),
     OneBotNoticeGroupMessageEvent {
@@ -132,7 +132,7 @@ internal class OneBotNoticeGroupMessageEventImpl(
 
 internal class OneBotDefaultGroupMessageEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupMessageEvent,
+    override val sourceEvent: RawGroupMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotGroupMessageEventImpl(sourceEvent, bot) {
     override fun toString(): String = eventToString("OneBotDefaultGroupMessageEvent")

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
@@ -34,7 +34,7 @@ import love.forte.simbot.component.onebot.v11.core.internal.message.OneBotMessag
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateTextMsgApi
-import love.forte.simbot.component.onebot.v11.event.message.PrivateMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
 import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
@@ -43,7 +43,7 @@ import love.forte.simbot.message.MessageContent
 
 
 internal abstract class OneBotPrivateMessageEventImpl(
-    final override val sourceEvent: PrivateMessageEvent,
+    final override val sourceEvent: RawPrivateMessageEvent,
     final override val bot: OneBotBotImpl,
 ) : OneBotPrivateMessageEvent {
     override val id: ID
@@ -88,7 +88,7 @@ internal abstract class OneBotPrivateMessageEventImpl(
 
 internal class OneBotFriendMessageEventImpl(
     override val sourceEventRaw: String?,
-    sourceEvent: PrivateMessageEvent,
+    sourceEvent: RawPrivateMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotPrivateMessageEventImpl(sourceEvent, bot),
     OneBotFriendMessageEvent {
@@ -102,7 +102,7 @@ internal class OneBotFriendMessageEventImpl(
 
 internal class OneBotGroupPrivateMessageEventImpl(
     override val sourceEventRaw: String?,
-    sourceEvent: PrivateMessageEvent,
+    sourceEvent: RawPrivateMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotPrivateMessageEventImpl(sourceEvent, bot),
     OneBotGroupPrivateMessageEvent {
@@ -121,7 +121,7 @@ internal class OneBotGroupPrivateMessageEventImpl(
 
 internal class OneBotDefaultPrivateMessageEventImpl(
     override val sourceEventRaw: String?,
-    sourceEvent: PrivateMessageEvent,
+    sourceEvent: RawPrivateMessageEvent,
     bot: OneBotBotImpl,
 ) : OneBotPrivateMessageEventImpl(sourceEvent, bot) {
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/meta/OneBotMetaEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/meta/OneBotMetaEventImpl.kt
@@ -24,8 +24,8 @@ import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.meta.OneBotHeartbeatEvent
 import love.forte.simbot.component.onebot.v11.core.event.meta.OneBotLifecycleEvent
 import love.forte.simbot.component.onebot.v11.core.event.meta.OneBotMetaEvent
-import love.forte.simbot.component.onebot.v11.event.meta.HeartbeatEvent
-import love.forte.simbot.component.onebot.v11.event.meta.LifecycleEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawHeartbeatEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawLifecycleEvent
 
 /**
  * OneBot中的元事件类型。
@@ -37,7 +37,7 @@ internal abstract class OneBotMetaEventImpl : OneBotMetaEvent {
 
 internal class OneBotHeartbeatEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: HeartbeatEvent,
+    override val sourceEvent: RawHeartbeatEvent,
     override val bot: OneBotBot,
 ) : OneBotHeartbeatEvent, OneBotMetaEventImpl() {
     override fun toString(): String =
@@ -46,7 +46,7 @@ internal class OneBotHeartbeatEventImpl(
 
 internal class OneBotLifecycleEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: LifecycleEvent,
+    override val sourceEvent: RawLifecycleEvent,
     override val bot: OneBotBot,
 ) : OneBotLifecycleEvent, OneBotMetaEventImpl() {
     override fun toString(): String =

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotFriendAddEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotFriendAddEventImpl.kt
@@ -22,7 +22,7 @@ import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotFriendAddEvent
-import love.forte.simbot.component.onebot.v11.event.notice.FriendAddEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawFriendAddEvent
 
 
 /**
@@ -31,7 +31,7 @@ import love.forte.simbot.component.onebot.v11.event.notice.FriendAddEvent
  */
 internal class OneBotFriendAddEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: FriendAddEvent,
+    override val sourceEvent: RawFriendAddEvent,
     override val bot: OneBotBot
 ) : OneBotFriendAddEvent {
     override val id: ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotFriendRecallEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotFriendRecallEventImpl.kt
@@ -23,7 +23,7 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotFriend
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotFriendRecallEvent
-import love.forte.simbot.component.onebot.v11.event.notice.FriendRecallEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawFriendRecallEvent
 
 
 /**
@@ -32,7 +32,7 @@ import love.forte.simbot.component.onebot.v11.event.notice.FriendRecallEvent
  */
 internal class OneBotFriendRecallEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: FriendRecallEvent,
+    override val sourceEvent: RawFriendRecallEvent,
     override val bot: OneBotBot
 ) : OneBotFriendRecallEvent {
     override val id: ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupAdminEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupAdminEventImpl.kt
@@ -24,11 +24,11 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupAdminEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupAdminEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupAdminEvent
 
 internal class OneBotGroupAdminEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupAdminEvent,
+    override val sourceEvent: RawGroupAdminEvent,
     override val bot: OneBotBot
 ) : OneBotGroupAdminEvent {
     override val id: ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupBanEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupBanEventImpl.kt
@@ -24,7 +24,7 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupBanEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupBanEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupBanEvent
 
 
 /**
@@ -33,7 +33,7 @@ import love.forte.simbot.component.onebot.v11.event.notice.GroupBanEvent
  */
 internal class OneBotGroupBanEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupBanEvent,
+    override val sourceEvent: RawGroupBanEvent,
     override val bot: OneBotBot
 ) : OneBotGroupBanEvent {
     override val id: ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupChangeEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupChangeEventImpl.kt
@@ -27,8 +27,8 @@ import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupChangeEvent
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupMemberDecreaseEvent
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupMemberIncreaseEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupDecreaseEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupIncreaseEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupDecreaseEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupIncreaseEvent
 
 
 /**
@@ -49,7 +49,7 @@ internal abstract class OneBotGroupChangeEventImpl : OneBotGroupChangeEvent {
 
 internal class OneBotGroupMemberIncreaseEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupIncreaseEvent,
+    override val sourceEvent: RawGroupIncreaseEvent,
     override val bot: OneBotBot
 ) : OneBotGroupChangeEventImpl(), OneBotGroupMemberIncreaseEvent {
     override suspend fun member(): OneBotMember {
@@ -68,7 +68,7 @@ internal class OneBotGroupMemberIncreaseEventImpl(
 
 internal class OneBotGroupMemberDecreaseEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupDecreaseEvent,
+    override val sourceEvent: RawGroupDecreaseEvent,
     override val bot: OneBotBotImpl
 ) : OneBotGroupChangeEventImpl(), OneBotGroupMemberDecreaseEvent {
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupRecallEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupRecallEventImpl.kt
@@ -23,7 +23,7 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupRecallEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupRecallEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupRecallEvent
 
 
 /**
@@ -32,7 +32,7 @@ import love.forte.simbot.component.onebot.v11.event.notice.GroupRecallEvent
  */
 internal class OneBotGroupRecallEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupRecallEvent,
+    override val sourceEvent: RawGroupRecallEvent,
     override val bot: OneBotBot
 ) : OneBotGroupRecallEvent {
     override val id: ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupUploadEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotGroupUploadEventImpl.kt
@@ -23,7 +23,7 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.OneBotGroupUploadEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupUploadEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupUploadEvent
 
 
 /**
@@ -32,7 +32,7 @@ import love.forte.simbot.component.onebot.v11.event.notice.GroupUploadEvent
  */
 internal class OneBotGroupUploadEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupUploadEvent,
+    override val sourceEvent: RawGroupUploadEvent,
     override val bot: OneBotBot
 ) : OneBotGroupUploadEvent {
     override val id: ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotNotifyEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotNotifyEventImpl.kt
@@ -24,7 +24,7 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.notice.*
-import love.forte.simbot.component.onebot.v11.event.notice.NotifyEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawNotifyEvent
 
 
 /**
@@ -33,7 +33,7 @@ import love.forte.simbot.component.onebot.v11.event.notice.NotifyEvent
  */
 internal abstract class OneBotNotifyEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: NotifyEvent,
+    override val sourceEvent: RawNotifyEvent,
     override val bot: OneBotBotImpl
 ) : OneBotNotifyEvent {
     override val id: ID
@@ -59,7 +59,7 @@ internal abstract class OneBotNotifyEventImpl(
 
 internal class OneBotHonorEventImpl(
     sourceEventRaw: String?,
-    sourceEvent: NotifyEvent,
+    sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
 ) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
     OneBotHonorEvent {
@@ -69,7 +69,7 @@ internal class OneBotHonorEventImpl(
 
 internal class OneBotLuckyKingEventImpl(
     sourceEventRaw: String?,
-    sourceEvent: NotifyEvent,
+    sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
 ) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
     OneBotLuckyKingEvent {
@@ -79,7 +79,7 @@ internal class OneBotLuckyKingEventImpl(
 
 internal class OneBotMemberPokeEventImpl(
     sourceEventRaw: String?,
-    sourceEvent: NotifyEvent,
+    sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
 ) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
     OneBotMemberPokeEvent {
@@ -89,7 +89,7 @@ internal class OneBotMemberPokeEventImpl(
 
 internal class OneBotBotSelfPokeEventImpl(
     sourceEventRaw: String?,
-    sourceEvent: NotifyEvent,
+    sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
 ) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
     OneBotBotSelfPokeEvent {

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/request/OneBotRequestEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/request/OneBotRequestEventImpl.kt
@@ -32,8 +32,8 @@ import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.request.*
-import love.forte.simbot.component.onebot.v11.event.request.FriendRequestEvent
-import love.forte.simbot.component.onebot.v11.event.request.GroupRequestEvent
+import love.forte.simbot.component.onebot.v11.event.request.RawFriendRequestEvent
+import love.forte.simbot.component.onebot.v11.event.request.RawGroupRequestEvent
 
 
 internal abstract class OneBotRequestEventImpl : OneBotRequestEvent {
@@ -61,7 +61,7 @@ internal abstract class OneBotRequestEventImpl : OneBotRequestEvent {
 
 internal class OneBotFriendRequestEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: FriendRequestEvent,
+    override val sourceEvent: RawFriendRequestEvent,
     override val bot: OneBotBot,
 ) : OneBotRequestEventImpl(), OneBotFriendRequestEvent {
     override suspend fun doAccept(options: Array<out AcceptOption>) {
@@ -90,7 +90,7 @@ internal class OneBotFriendRequestEventImpl(
 
 internal class OneBotGroupRequestEventImpl(
     override val sourceEventRaw: String?,
-    override val sourceEvent: GroupRequestEvent,
+    override val sourceEvent: RawGroupRequestEvent,
     override val bot: OneBotBotImpl,
 ) : OneBotRequestEventImpl(), OneBotGroupRequestEvent {
     override suspend fun doAccept(options: Array<out AcceptOption>) {

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupMessageEvent.kt
@@ -21,7 +21,7 @@ import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.event.message.GroupMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
 import love.forte.simbot.event.ChatGroupEvent
 import love.forte.simbot.event.ChatGroupMessageEvent
 import love.forte.simbot.suspendrunner.STP
@@ -30,7 +30,7 @@ import love.forte.simbot.suspendrunner.STP
 /**
  * [群消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#群消息)
  *
- * @see GroupMessageEvent
+ * @see RawGroupMessageEvent
  *
  * @see OneBotNormalGroupMessageEvent
  * @see OneBotAnonymousGroupMessageEvent
@@ -40,7 +40,7 @@ import love.forte.simbot.suspendrunner.STP
  */
 @STP
 public interface OneBotGroupMessageEvent : OneBotMessageEvent, ChatGroupEvent {
-    override val sourceEvent: GroupMessageEvent
+    override val sourceEvent: RawGroupMessageEvent
 
     /**
      * 事件发生所在群

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/message/OneBotMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/message/OneBotMessageEvent.kt
@@ -30,7 +30,7 @@ import love.forte.simbot.suspendrunner.ST
 /**
  * OneBot11原始的消息事件结构体定义类型。
  */
-public typealias OBSourceMessageEvent = love.forte.simbot.component.onebot.v11.event.message.MessageEvent
+public typealias OBSourceMessageEvent = love.forte.simbot.component.onebot.v11.event.message.RawMessageEvent
 
 /**
  * OneBot组件中的消息相关事件。

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/message/OneBotPrivateMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/message/OneBotPrivateMessageEvent.kt
@@ -20,7 +20,7 @@ package love.forte.simbot.component.onebot.v11.core.event.message
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotFriend
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.event.message.PrivateMessageEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.event.ContactMessageEvent
 import love.forte.simbot.event.MemberMessageEvent
 import love.forte.simbot.suspendrunner.STP
@@ -29,14 +29,14 @@ import love.forte.simbot.suspendrunner.STP
 /**
  * [私聊消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#私聊消息)
  *
- * @see PrivateMessageEvent
+ * @see RawPrivateMessageEvent
  * @see OneBotFriendMessageEvent
  * @see OneBotGroupPrivateMessageEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotPrivateMessageEvent : OneBotMessageEvent {
-    override val sourceEvent: PrivateMessageEvent
+    override val sourceEvent: RawPrivateMessageEvent
 
     /**
      * private 消息类型

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/meta/OneBotHeartbeatEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/meta/OneBotHeartbeatEvent.kt
@@ -18,8 +18,8 @@
 package love.forte.simbot.component.onebot.v11.core.event.meta
 
 import love.forte.simbot.component.onebot.v11.common.api.StatusResult
-import love.forte.simbot.component.onebot.v11.event.meta.HeartbeatEvent
-import love.forte.simbot.component.onebot.v11.event.meta.MetaEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawHeartbeatEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawMetaEvent
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -27,12 +27,12 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * [心跳事件](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#心跳)
  *
- * @see MetaEvent
+ * @see RawMetaEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotHeartbeatEvent : OneBotMetaEvent {
-    override val sourceEvent: HeartbeatEvent
+    override val sourceEvent: RawHeartbeatEvent
 
     /**
      * 状态信息

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/meta/OneBotLifecycleEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/meta/OneBotLifecycleEvent.kt
@@ -17,18 +17,18 @@
 
 package love.forte.simbot.component.onebot.v11.core.event.meta
 
-import love.forte.simbot.component.onebot.v11.event.meta.LifecycleEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawLifecycleEvent
 
 
 /**
  * [生命周期](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#生命周期)
  *
- * @see LifecycleEvent
+ * @see RawLifecycleEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotLifecycleEvent : OneBotMetaEvent {
-    override val sourceEvent: LifecycleEvent
+    override val sourceEvent: RawLifecycleEvent
 
     /**
      * 事件子类型，分别表示 OneBot 启用、停用、WebSocket 连接成功.

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/meta/OneBotMetaEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/meta/OneBotMetaEvent.kt
@@ -18,7 +18,7 @@
 package love.forte.simbot.component.onebot.v11.core.event.meta
 
 import love.forte.simbot.component.onebot.v11.core.event.OneBotBotEvent
-import love.forte.simbot.component.onebot.v11.event.meta.MetaEvent
+import love.forte.simbot.component.onebot.v11.event.meta.RawMetaEvent
 
 
 /**
@@ -26,5 +26,5 @@ import love.forte.simbot.component.onebot.v11.event.meta.MetaEvent
  * @author ForteScarlet
  */
 public interface OneBotMetaEvent : OneBotBotEvent {
-    override val sourceEvent: MetaEvent
+    override val sourceEvent: RawMetaEvent
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendAddEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendAddEvent.kt
@@ -18,16 +18,16 @@
 package love.forte.simbot.component.onebot.v11.core.event.notice
 
 import love.forte.simbot.common.id.LongID
-import love.forte.simbot.component.onebot.v11.event.notice.FriendAddEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawFriendAddEvent
 
 
 /**
  * 好友新增事件。
  *
- * @see FriendAddEvent
+ * @see RawFriendAddEvent
  */
 public interface OneBotFriendAddEvent : OneBotNoticeEvent {
-    override val sourceEvent: FriendAddEvent
+    override val sourceEvent: RawFriendAddEvent
 
     /**
      * 此好友的ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendRecallEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendRecallEvent.kt
@@ -20,18 +20,18 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotFriend
-import love.forte.simbot.component.onebot.v11.event.notice.FriendRecallEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawFriendRecallEvent
 import love.forte.simbot.event.ContactEvent
 import love.forte.simbot.suspendrunner.STP
 
 
 /**
  * 好友消息撤回事件
- * @see FriendRecallEvent
+ * @see RawFriendRecallEvent
  * @author ForteScarlet
  */
 public interface OneBotFriendRecallEvent : OneBotNoticeEvent, ContactEvent {
-    override val sourceEvent: FriendRecallEvent
+    override val sourceEvent: RawFriendRecallEvent
 
     /**
      * 消息ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupAdminEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupAdminEvent.kt
@@ -20,19 +20,19 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.event.notice.GroupAdminEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupAdminEvent
 import love.forte.simbot.event.MemberEvent
 import love.forte.simbot.suspendrunner.STP
 
 
 /**
  * 群管理员变动事件
- * @see GroupAdminEvent
+ * @see RawGroupAdminEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotGroupAdminEvent : OneBotNoticeEvent, MemberEvent {
-    override val sourceEvent: GroupAdminEvent
+    override val sourceEvent: RawGroupAdminEvent
 
     /**
      * 群号
@@ -50,17 +50,17 @@ public interface OneBotGroupAdminEvent : OneBotNoticeEvent, MemberEvent {
      * 事件子类型，分别表示设置和取消管理员。
      * 可能的值: `set`、`unset`
      *
-     * @see GroupAdminEvent.subType
+     * @see RawGroupAdminEvent.subType
      */
     public val subType: String
         get() = sourceEvent.subType
 
     /**
      * 是被 _任职_ 为管理，
-     * 即 [subType] == [GroupAdminEvent.SUB_TYPE_SET].
+     * 即 [subType] == [RawGroupAdminEvent.SUB_TYPE_SET].
      */
     public val isSet: Boolean
-        get() = subType == GroupAdminEvent.SUB_TYPE_SET
+        get() = subType == RawGroupAdminEvent.SUB_TYPE_SET
 
     /**
      * 群

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupBanEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupBanEvent.kt
@@ -20,7 +20,7 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.event.notice.GroupBanEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupBanEvent
 import love.forte.simbot.event.MemberEvent
 import love.forte.simbot.suspendrunner.STP
 import kotlin.time.Duration
@@ -30,28 +30,28 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * 群禁言事件
  *
- * @see GroupBanEvent
+ * @see RawGroupBanEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotGroupBanEvent : OneBotNoticeEvent, MemberEvent {
-    override val sourceEvent: GroupBanEvent
+    override val sourceEvent: RawGroupBanEvent
 
     /**
      * 事件子类型，分别表示禁言、解除禁言。
      * 可能的值: `ban`、`lift_ban`
      *
-     * @see GroupBanEvent.subType
+     * @see RawGroupBanEvent.subType
      */
     public val subType: String
         get() = sourceEvent.subType
 
     /**
      * 是否为禁言。
-     * 即 [subType] == [GroupBanEvent.SUB_TYPE_BAN]
+     * 即 [subType] == [RawGroupBanEvent.SUB_TYPE_BAN]
      */
     public val isBan: Boolean
-        get() = subType == GroupBanEvent.SUB_TYPE_BAN
+        get() = subType == RawGroupBanEvent.SUB_TYPE_BAN
 
     /**
      * 群号
@@ -74,7 +74,7 @@ public interface OneBotGroupBanEvent : OneBotNoticeEvent, MemberEvent {
     /**
      * 禁言时长，单位秒。
      *
-     * @see GroupBanEvent.duration
+     * @see RawGroupBanEvent.duration
      */
     public val durationSeconds: Long
         get() = sourceEvent.duration

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupChangeEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupChangeEvent.kt
@@ -20,8 +20,8 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.event.notice.GroupDecreaseEvent
-import love.forte.simbot.component.onebot.v11.event.notice.GroupIncreaseEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupDecreaseEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupIncreaseEvent
 import love.forte.simbot.event.MemberDecreaseEvent
 import love.forte.simbot.event.MemberIncreaseEvent
 import love.forte.simbot.event.MemberIncreaseOrDecreaseEvent
@@ -64,10 +64,10 @@ public interface OneBotGroupChangeEvent : OneBotNoticeEvent, MemberIncreaseOrDec
 /**
  * 群成员增加事件
  *
- * @see GroupIncreaseEvent
+ * @see RawGroupIncreaseEvent
  */
 public interface OneBotGroupMemberIncreaseEvent : OneBotGroupChangeEvent, MemberIncreaseEvent {
-    override val sourceEvent: GroupIncreaseEvent
+    override val sourceEvent: RawGroupIncreaseEvent
 
     /**
      * 群号
@@ -99,10 +99,10 @@ public interface OneBotGroupMemberIncreaseEvent : OneBotGroupChangeEvent, Member
 /**
  * 群成员减少事件
  *
- * @see GroupDecreaseEvent
+ * @see RawGroupDecreaseEvent
  */
 public interface OneBotGroupMemberDecreaseEvent : OneBotGroupChangeEvent, MemberDecreaseEvent {
-    override val sourceEvent: GroupDecreaseEvent
+    override val sourceEvent: RawGroupDecreaseEvent
 
     /**
      * 群号

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupRecallEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupRecallEvent.kt
@@ -20,7 +20,7 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
-import love.forte.simbot.component.onebot.v11.event.notice.GroupRecallEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupRecallEvent
 import love.forte.simbot.event.ChatGroupEvent
 import love.forte.simbot.suspendrunner.STP
 
@@ -28,12 +28,12 @@ import love.forte.simbot.suspendrunner.STP
 /**
  * 群消息撤回事件
  *
- * @see GroupRecallEvent
+ * @see RawGroupRecallEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotGroupRecallEvent : OneBotNoticeEvent, ChatGroupEvent {
-    override val sourceEvent: GroupRecallEvent
+    override val sourceEvent: RawGroupRecallEvent
 
     /**
      * 消息ID

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupUploadEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupUploadEvent.kt
@@ -19,7 +19,7 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
-import love.forte.simbot.component.onebot.v11.event.notice.GroupUploadEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawGroupUploadEvent
 import love.forte.simbot.event.ChatGroupEvent
 import love.forte.simbot.suspendrunner.STP
 
@@ -27,11 +27,11 @@ import love.forte.simbot.suspendrunner.STP
 /**
  * 群文件上传事件
  *
- * @see GroupUploadEvent
+ * @see RawGroupUploadEvent
  * @author ForteScarlet
  */
 public interface OneBotGroupUploadEvent : OneBotNoticeEvent, ChatGroupEvent {
-    override val sourceEvent: GroupUploadEvent
+    override val sourceEvent: RawGroupUploadEvent
 
     /**
      * 群号
@@ -46,11 +46,11 @@ public interface OneBotGroupUploadEvent : OneBotNoticeEvent, ChatGroupEvent {
         get() = sourceEvent.userId
 
     /**
-     * [GroupUploadEvent] 原始事件中的 [文件信息][GroupUploadEvent.file]
+     * [RawGroupUploadEvent] 原始事件中的 [文件信息][RawGroupUploadEvent.file]
      *
-     * @see GroupUploadEvent.file
+     * @see RawGroupUploadEvent.file
      */
-    public val fileInfo: GroupUploadEvent.FileInfo
+    public val fileInfo: RawGroupUploadEvent.FileInfo
         get() = sourceEvent.file
 
     /**

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent.kt
@@ -18,16 +18,16 @@
 package love.forte.simbot.component.onebot.v11.core.event.notice
 
 import love.forte.simbot.component.onebot.v11.core.event.OneBotBotEvent
-import love.forte.simbot.component.onebot.v11.event.notice.NoticeEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawNoticeEvent
 
 
 /**
  * 通知事件
  *
- * @see NoticeEvent
+ * @see RawNoticeEvent
  *
  * @author ForteScarlet
  */
 public interface OneBotNoticeEvent : OneBotBotEvent {
-    override val sourceEvent: NoticeEvent
+    override val sourceEvent: RawNoticeEvent
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent.kt
@@ -20,7 +20,7 @@ package love.forte.simbot.component.onebot.v11.core.event.notice
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
-import love.forte.simbot.component.onebot.v11.event.notice.NotifyEvent
+import love.forte.simbot.component.onebot.v11.event.notice.RawNotifyEvent
 import love.forte.simbot.event.MemberEvent
 import love.forte.simbot.suspendrunner.STP
 
@@ -28,19 +28,19 @@ import love.forte.simbot.suspendrunner.STP
 /**
  * 群成员荣誉变更事件、红包人气王事件或戳一戳事件。
  *
- * @see NotifyEvent
+ * @see RawNotifyEvent
  * @see OneBotHonorEvent
  * @see OneBotLuckyKingEvent
  * @see OneBotPokeEvent
  * @author ForteScarlet
  */
 public interface OneBotNotifyEvent : OneBotNoticeEvent, MemberEvent {
-    override val sourceEvent: NotifyEvent
+    override val sourceEvent: RawNotifyEvent
 
     /**
      * 荣誉类型.
      *
-     * @see NotifyEvent.honorType
+     * @see RawNotifyEvent.honorType
      */
     public val honorType: String?
         get() = sourceEvent.honorType
@@ -82,7 +82,7 @@ public interface OneBotHonorEvent : OneBotNotifyEvent {
     /**
      * 荣誉类型.
      *
-     * @see NotifyEvent.honorType
+     * @see RawNotifyEvent.honorType
      */
     override val honorType: String
         get() = sourceEvent.honorType!!

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent.kt
@@ -23,21 +23,21 @@ import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotStranger
 import love.forte.simbot.component.onebot.v11.core.event.OneBotBotEvent
-import love.forte.simbot.component.onebot.v11.event.request.FriendRequestEvent
-import love.forte.simbot.component.onebot.v11.event.request.GroupRequestEvent
+import love.forte.simbot.component.onebot.v11.event.request.RawFriendRequestEvent
+import love.forte.simbot.component.onebot.v11.event.request.RawGroupRequestEvent
 import love.forte.simbot.event.OrganizationJoinRequestEvent
 import love.forte.simbot.event.RequestEvent
 import love.forte.simbot.suspendrunner.STP
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.JvmSynthetic
 
-public typealias OBSourceRequestEvent = love.forte.simbot.component.onebot.v11.event.request.RequestEvent
+public typealias OBSourceRequestEvent = love.forte.simbot.component.onebot.v11.event.request.RawRequestEvent
 
 /**
- * OneBot组件中的 [事件请求][love.forte.simbot.component.onebot.v11.event.request.RequestEvent]
+ * OneBot组件中的 [事件请求][love.forte.simbot.component.onebot.v11.event.request.RawRequestEvent]
  * 的组件事件类型。
  *
- * @see love.forte.simbot.component.onebot.v11.event.request.RequestEvent
+ * @see love.forte.simbot.component.onebot.v11.event.request.RawRequestEvent
  * @see OneBotFriendRequestEvent
  * @see OneBotGroupRequestEvent
  *
@@ -73,10 +73,10 @@ public interface OneBotRequestEvent : OneBotBotEvent, RequestEvent {
 
 /**
  * 好友添加申请事件
- * @see FriendRequestEvent
+ * @see RawFriendRequestEvent
  */
 public interface OneBotFriendRequestEvent : OneBotRequestEvent {
-    override val sourceEvent: FriendRequestEvent
+    override val sourceEvent: RawFriendRequestEvent
 
     /**
      * 好友添加申请始终是 [主动地][RequestEvent.Type.PROACTIVE]
@@ -87,7 +87,7 @@ public interface OneBotFriendRequestEvent : OneBotRequestEvent {
     /**
      * 验证信息。
      *
-     * @see FriendRequestEvent.comment
+     * @see RawFriendRequestEvent.comment
      */
     override val message: String
         get() = sourceEvent.comment
@@ -95,7 +95,7 @@ public interface OneBotFriendRequestEvent : OneBotRequestEvent {
     /**
      * 请求 flag，在调用处理请求的 API 时需要传入
      *
-     * @see FriendRequestEvent.flag
+     * @see RawFriendRequestEvent.flag
      */
     public val flag: String
         get() = sourceEvent.flag
@@ -103,7 +103,7 @@ public interface OneBotFriendRequestEvent : OneBotRequestEvent {
     /**
      * 发送请求的 QQ 号
      *
-     * @see FriendRequestEvent.userId
+     * @see RawFriendRequestEvent.userId
      */
     public val requesterId: LongID
         get() = sourceEvent.userId
@@ -144,10 +144,10 @@ public sealed class OneBotFriendRequestAcceptOption : AcceptOption {
 
 /**
  * 群添加申请事件
- * @see GroupRequestEvent
+ * @see RawGroupRequestEvent
  */
 public interface OneBotGroupRequestEvent : OneBotRequestEvent, OrganizationJoinRequestEvent {
-    override val sourceEvent: GroupRequestEvent
+    override val sourceEvent: RawGroupRequestEvent
 
     /**
      * 申请加入的群。
@@ -156,21 +156,21 @@ public interface OneBotGroupRequestEvent : OneBotRequestEvent, OrganizationJoinR
     override suspend fun content(): OneBotGroup
 
     /**
-     * 根据 [GroupRequestEvent.subType] 的值区分类型。
+     * 根据 [RawGroupRequestEvent.subType] 的值区分类型。
      * 如果是 `invite` 则为被动，否则（包括 `add`）均视为主动。
      *
      */
     override val type: RequestEvent.Type
         get() = when (sourceEvent.subType) {
-            GroupRequestEvent.SUB_TYPE_INVITE -> RequestEvent.Type.PASSIVE
-            GroupRequestEvent.SUB_TYPE_ADD -> RequestEvent.Type.PROACTIVE
+            RawGroupRequestEvent.SUB_TYPE_INVITE -> RequestEvent.Type.PASSIVE
+            RawGroupRequestEvent.SUB_TYPE_ADD -> RequestEvent.Type.PROACTIVE
             else -> RequestEvent.Type.PROACTIVE
         }
 
     /**
      * 验证信息。
      *
-     * @see GroupRequestEvent.comment
+     * @see RawGroupRequestEvent.comment
      */
     override val message: String
         get() = sourceEvent.comment
@@ -178,7 +178,7 @@ public interface OneBotGroupRequestEvent : OneBotRequestEvent, OrganizationJoinR
     /**
      * 请求 flag，在调用处理请求的 API 时需要传入
      *
-     * @see GroupRequestEvent.flag
+     * @see RawGroupRequestEvent.flag
      */
     public val flag: String
         get() = sourceEvent.flag
@@ -186,7 +186,7 @@ public interface OneBotGroupRequestEvent : OneBotRequestEvent, OrganizationJoinR
     /**
      * 发送请求的 QQ 号
      *
-     * @see GroupRequestEvent.userId
+     * @see RawGroupRequestEvent.userId
      */
     override val requesterId: LongID
         get() = sourceEvent.userId

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/core/event/ResolveRawEventToEventTests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/core/event/ResolveRawEventToEventTests.kt
@@ -2,8 +2,8 @@ package love.forte.simbot.component.onebot.v11.core.event
 
 import kotlinx.serialization.KSerializer
 import love.forte.simbot.component.onebot.v11.core.OneBot11
-import love.forte.simbot.component.onebot.v11.event.Event
-import love.forte.simbot.component.onebot.v11.event.message.GroupMessageEvent
+import love.forte.simbot.component.onebot.v11.event.RawEvent
+import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
 
 
 /**
@@ -15,14 +15,14 @@ class ResolveRawEventToEventTests {
     // @Test // TODO
     fun resolveGroupMessageEventTest() {
         val event = decodeEvent(
-            GroupMessageEvent.serializer(),
+            RawGroupMessageEvent.serializer(),
             ""
         )
 
     }
 }
 
-private fun <T : Event> decodeEvent(
+private fun <T : RawEvent> decodeEvent(
     serializer: KSerializer<out T>,
     raw: String
 ): T {

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/RawEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/RawEvent.kt
@@ -63,7 +63,7 @@ import love.forte.simbot.component.onebot.common.annotations.InternalOneBotAPI
  *
  * @author ForteScarlet
  */
-public interface Event {
+public interface RawEvent {
     /**
      * 事件发生的时间戳
      */
@@ -82,12 +82,12 @@ public interface Event {
 
 /**
  * 标记在一个具体地可序列化事件类型上，
- * 表示它的 [Event.postType] 的预期值。
+ * 表示它的 [RawEvent.postType] 的预期值。
  *
  * ### 二级分类
  *
  * 一个事件通常通过两个属性来确定最终的类型：
- * 首先通过 [Event.postType] 确定大分类（比如 `message`、`notice` 等），
+ * 首先通过 [RawEvent.postType] 确定大分类（比如 `message`、`notice` 等），
  * 其次通过一个子类型来确定具体的类型(
  * 比如 `message` 事件中的 `message_type`,
  * `notice` 事件中的 `notice_type`

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/UnknownEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/UnknownEvent.kt
@@ -22,7 +22,7 @@ import love.forte.simbot.common.id.LongID
 
 
 /**
- * 用于“兜底”的 [Event] 类型实现。
+ * 用于“兜底”的 [RawEvent] 类型实现。
  * 当出现了尚未支持或某种未知的事件体，无法对应到任何现有的已定义结构时，
  * 则应当将其解析并包装为 [UnknownEvent]。
  *
@@ -43,4 +43,4 @@ public data class UnknownEvent(
      * 原始的JSON字符串
      */
     public val raw: String,
-) : Event
+) : RawEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent.kt
@@ -21,28 +21,32 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
-import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 import love.forte.simbot.component.onebot.common.annotations.SourceEventConstructor
+import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegment
 
 /**
- * [私聊消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#私聊消息)
- *
+ * [群消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#群消息)
  * @property time 事件发生的时间戳
  * @property selfId 收到事件的机器人 QQ 号
  * @property postType 上报类型
  * @property messageType 消息类型
- * @property subType 消息子类型，如果是好友则是 `friend`，如果是群临时会话则是 `group`
+ * @property subType 消息子类型，正常消息是 `normal`，匿名消息是 `anonymous`，
+ * 系统提示（如「管理员已禁止群内匿名聊天」）是 `notice`
+ * @property anonymous 匿名信息，如果不是匿名消息则为 `null`
  * @property messageId 消息 ID
+ * @property groupId 群号
  * @property userId 发送者 QQ 号
  * @property message 消息内容
  * @property rawMessage 原始消息内容
  * @property font 字体
  * @property sender 发送人信息
+ *
+ *
  */
 @Serializable
-@ExpectEventType(postType = MessageEvent.POST_TYPE, subType = "private")
-public data class PrivateMessageEvent @SourceEventConstructor constructor(
+@ExpectEventType(postType = RawMessageEvent.POST_TYPE, subType = "group")
+public data class RawGroupMessageEvent @SourceEventConstructor constructor(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -50,10 +54,13 @@ public data class PrivateMessageEvent @SourceEventConstructor constructor(
     override val postType: String,
     @SerialName("message_id")
     override val messageId: ID,
+    @SerialName("group_id")
+    public val groupId: LongID,
     @SerialName("message_type")
     override val messageType: String,
     @SerialName("sub_type")
     override val subType: String,
+    public val anonymous: Anonymous? = null,
     override val message: List<OneBotMessageSegment> = emptyList(),
     @SerialName("raw_message")
     override val rawMessage: String,
@@ -61,29 +68,51 @@ public data class PrivateMessageEvent @SourceEventConstructor constructor(
     override val userId: LongID,
     override val font: Int?,
     override val sender: Sender
-) : MessageEvent {
+) : RawMessageEvent {
+
     /**
-     * 私聊事件的发送人信息
+     * 匿名信息
+     *
+     * @property id 匿名用户 ID
+     * @property name 匿名用户名称
+     * @property flag 匿名用户 `flag`，在调用禁言 API 时需要传入
+     */
+    @Serializable
+    public data class Anonymous @SourceEventConstructor constructor(
+        val id: LongID,
+        val name: String,
+        val flag: String,
+    )
+
+    /**
+     * 群消息的发送人信息
+     *
+     * @property role 角色，`owner` 或 `admin` 或 `member`
      */
     @Serializable
     public data class Sender @SourceEventConstructor constructor(
         @SerialName("user_id")
         override val userId: LongID,
         override val nickname: String,
+        public val card: String = "",
+        public val area: String? = null,
+        public val level: Int? = null,
+        public val role: String,
+        public val title: String? = null,
         override val sex: String = DEFAULT_SEX,
-        override val age: Int = DEFAULT_AGE
-    ) : MessageEvent.Sender
+        override val age: Int = DEFAULT_AGE,
+    ) : RawMessageEvent.Sender
+
 
     public companion object {
-        /**
-         * @see PrivateMessageEvent.subType
-         */
-        public const val SUB_TYPE_FRIEND: String = "friend"
+        /** @see RawGroupMessageEvent.subType */
+        public const val SUB_TYPE_NORMAL: String = "normal"
 
-        /**
-         * @see PrivateMessageEvent.subType
-         */
-        public const val SUB_TYPE_GROUP: String = "group"
+        /** @see RawGroupMessageEvent.subType */
+        public const val SUB_TYPE_ANONYMOUS: String = "anonymous"
+
+        /** @see RawGroupMessageEvent.subType */
+        public const val SUB_TYPE_NOTICE: String = "notice"
 
     }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent.kt
@@ -19,7 +19,7 @@ package love.forte.simbot.component.onebot.v11.event.message
 
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
-import love.forte.simbot.component.onebot.v11.event.Event
+import love.forte.simbot.component.onebot.v11.event.RawEvent
 import love.forte.simbot.component.onebot.v11.event.ExpectEventSubTypeProperty
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegment
 
@@ -27,14 +27,14 @@ import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegme
 /**
  * [消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#消息事件)
  *
- * [MessageEvent] 中定义的属性为针对私聊消息和群消息事件属性中人为抽取的 _可能公共_ 属性，
+ * [RawMessageEvent] 中定义的属性为针对私聊消息和群消息事件属性中人为抽取的 _可能公共_ 属性，
  * 并非协议中明确定义一定相同的公共属性。
  * 此处只做最低限度的公共抽取。
  *
  * @author ForteScarlet
  */
-@ExpectEventSubTypeProperty(value = "messageType", postType = MessageEvent.POST_TYPE, name = "message_type")
-public interface MessageEvent : Event {
+@ExpectEventSubTypeProperty(value = "messageType", postType = RawMessageEvent.POST_TYPE, name = "message_type")
+public interface RawMessageEvent : RawEvent {
     /**
      * 消息 ID
      */

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent.kt
@@ -21,32 +21,28 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
-import love.forte.simbot.component.onebot.common.annotations.SourceEventConstructor
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
+import love.forte.simbot.component.onebot.common.annotations.SourceEventConstructor
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegment
 
 /**
- * [群消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#群消息)
+ * [私聊消息事件](https://github.com/botuniverse/onebot-11/blob/master/event/message.md#私聊消息)
+ *
  * @property time 事件发生的时间戳
  * @property selfId 收到事件的机器人 QQ 号
  * @property postType 上报类型
  * @property messageType 消息类型
- * @property subType 消息子类型，正常消息是 `normal`，匿名消息是 `anonymous`，
- * 系统提示（如「管理员已禁止群内匿名聊天」）是 `notice`
- * @property anonymous 匿名信息，如果不是匿名消息则为 `null`
+ * @property subType 消息子类型，如果是好友则是 `friend`，如果是群临时会话则是 `group`
  * @property messageId 消息 ID
- * @property groupId 群号
  * @property userId 发送者 QQ 号
  * @property message 消息内容
  * @property rawMessage 原始消息内容
  * @property font 字体
  * @property sender 发送人信息
- *
- *
  */
 @Serializable
-@ExpectEventType(postType = MessageEvent.POST_TYPE, subType = "group")
-public data class GroupMessageEvent @SourceEventConstructor constructor(
+@ExpectEventType(postType = RawMessageEvent.POST_TYPE, subType = "private")
+public data class RawPrivateMessageEvent @SourceEventConstructor constructor(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -54,13 +50,10 @@ public data class GroupMessageEvent @SourceEventConstructor constructor(
     override val postType: String,
     @SerialName("message_id")
     override val messageId: ID,
-    @SerialName("group_id")
-    public val groupId: LongID,
     @SerialName("message_type")
     override val messageType: String,
     @SerialName("sub_type")
     override val subType: String,
-    public val anonymous: Anonymous? = null,
     override val message: List<OneBotMessageSegment> = emptyList(),
     @SerialName("raw_message")
     override val rawMessage: String,
@@ -68,51 +61,29 @@ public data class GroupMessageEvent @SourceEventConstructor constructor(
     override val userId: LongID,
     override val font: Int?,
     override val sender: Sender
-) : MessageEvent {
-
+) : RawMessageEvent {
     /**
-     * 匿名信息
-     *
-     * @property id 匿名用户 ID
-     * @property name 匿名用户名称
-     * @property flag 匿名用户 `flag`，在调用禁言 API 时需要传入
-     */
-    @Serializable
-    public data class Anonymous @SourceEventConstructor constructor(
-        val id: LongID,
-        val name: String,
-        val flag: String,
-    )
-
-    /**
-     * 群消息的发送人信息
-     *
-     * @property role 角色，`owner` 或 `admin` 或 `member`
+     * 私聊事件的发送人信息
      */
     @Serializable
     public data class Sender @SourceEventConstructor constructor(
         @SerialName("user_id")
         override val userId: LongID,
         override val nickname: String,
-        public val card: String = "",
-        public val area: String? = null,
-        public val level: Int? = null,
-        public val role: String,
-        public val title: String? = null,
         override val sex: String = DEFAULT_SEX,
-        override val age: Int = DEFAULT_AGE,
-    ) : MessageEvent.Sender
-
+        override val age: Int = DEFAULT_AGE
+    ) : RawMessageEvent.Sender
 
     public companion object {
-        /** @see GroupMessageEvent.subType */
-        public const val SUB_TYPE_NORMAL: String = "normal"
+        /**
+         * @see RawPrivateMessageEvent.subType
+         */
+        public const val SUB_TYPE_FRIEND: String = "friend"
 
-        /** @see GroupMessageEvent.subType */
-        public const val SUB_TYPE_ANONYMOUS: String = "anonymous"
-
-        /** @see GroupMessageEvent.subType */
-        public const val SUB_TYPE_NOTICE: String = "notice"
+        /**
+         * @see RawPrivateMessageEvent.subType
+         */
+        public const val SUB_TYPE_GROUP: String = "group"
 
     }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent.kt
@@ -15,42 +15,35 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.notice
+package love.forte.simbot.component.onebot.v11.event.meta
 
-import kotlin.Long
-import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.LongID
+import love.forte.simbot.component.onebot.v11.common.api.StatusResult
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
+
 /**
- * [群消息撤回](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群消息撤回)
+ * [心跳](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#心跳)
  *
- * @property groupId 群号。
- * @property userId 消息发送者 QQ 号。
- * @property operatorId 操作者 QQ 号。
- * @property messageId 被撤回的消息 ID。
+ * > 其中 `status` 字段的内容和 `get_status` 接口的快速操作相同。
+ *
+ * @property status 状态信息
+ * @property interval 到下次心跳的间隔，单位毫秒
+ *
+ * @author ForteScarlet
  */
-@ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "group_recall",
-)
 @Serializable
-public data class GroupRecallEvent(
+@ExpectEventType(postType = RawMetaEvent.POST_TYPE, subType = "heartbeat")
+public data class RawHeartbeatEvent(
     override val time: Long,
+    @SerialName("meta_event_type")
+    override val metaEventType: String,
     @SerialName("self_id")
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
-    @SerialName("notice_type")
-    override val noticeType: String,
-    @SerialName("group_id")
-    public val groupId: LongID,
-    @SerialName("user_id")
-    public val userId: LongID,
-    @SerialName("operator_id")
-    public val operatorId: LongID,
-    @SerialName("message_id")
-    public val messageId: LongID,
-) : NoticeEvent
+    public val status: StatusResult,
+    public val interval: Long,
+) : RawMetaEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent.kt
@@ -15,52 +15,32 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.notice
+package love.forte.simbot.component.onebot.v11.event.meta
 
-import kotlin.Long
-import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [群管理员变动](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群管理员变动)
+ * [生命周期](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#生命周期)
  *
- * @property subType 事件子类型，分别表示设置和取消管理员。
- * 可能的值: `set`、`unset`
- * @property groupId 群号。
- * @property userId 管理员 QQ 号。
+ *
+ * @property subType 事件子类型，分别表示 OneBot 启用、停用、WebSocket 连接成功.
+ * 可能的值: `enable`、`disable`、`connect`.
+ * 注意，目前生命周期元事件中，只有 HTTP POST 的情况下可以收到 `enable` 和 `disable`，
+ * 只有正向 WebSocket 和反向 WebSocket 可以收到 `connect`。
  */
-@ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "group_admin",
-)
 @Serializable
-public data class GroupAdminEvent(
+@ExpectEventType(postType = RawMetaEvent.POST_TYPE, subType = "lifecycle")
+public data class RawLifecycleEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
-    @SerialName("notice_type")
-    override val noticeType: String,
+    @SerialName("meta_event_type")
+    override val metaEventType: String,
     @SerialName("sub_type")
     public val subType: String,
-    @SerialName("group_id")
-    public val groupId: LongID,
-    @SerialName("user_id")
-    public val userId: LongID,
-) : NoticeEvent {
-    public companion object {
-        /**
-         * @see GroupAdminEvent.subType
-         */
-        public const val SUB_TYPE_SET: String = "set"
-
-        /**
-         * @see GroupAdminEvent.subType
-         */
-        public const val SUB_TYPE_UNSET: String = "unset"
-    }
-}
+) : RawMetaEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent.kt
@@ -15,25 +15,32 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.notice
+package love.forte.simbot.component.onebot.v11.event.meta
 
-import love.forte.simbot.component.onebot.v11.event.Event
+import love.forte.simbot.component.onebot.v11.event.RawEvent
 import love.forte.simbot.component.onebot.v11.event.ExpectEventSubTypeProperty
 
 
 /**
- * [通知事件](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md)
+ *
+ * [元事件](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md)
+ *
+ * > 消息、通知、请求三大类事件是与聊天软件直接相关的、机器人真实接收到的事件，
+ * 除了这些，OneBot 自己还会产生一类事件，这里称之为「元事件」，
+ * 例如生命周期事件、心跳事件等，这类事件与 OneBot 本身的运行状态有关，
+ * 而与聊天软件无关。元事件的上报方式和普通事件完全一样。
  *
  * @author ForteScarlet
  */
-@ExpectEventSubTypeProperty(value = "noticeType", postType = NoticeEvent.POST_TYPE, name = "notice_type")
-public interface NoticeEvent : Event {
+@ExpectEventSubTypeProperty(value = "metaEventType", postType = RawMetaEvent.POST_TYPE, name = "meta_event_type")
+public interface RawMetaEvent : RawEvent {
     /**
-     * 通知类型
+     * 元事件类型
      */
-    public val noticeType: String
+    public val metaEventType: String
 
     public companion object {
-        public const val POST_TYPE: String = "notice"
+        public const val POST_TYPE: String = "meta_event"
     }
 }
+

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent.kt
@@ -15,35 +15,31 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.request
+package love.forte.simbot.component.onebot.v11.event.notice
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
-
 /**
- * [加好友请求](https://github.com/botuniverse/onebot-11/blob/master/event/request.md#加好友请求)
+ * [好友添加](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#好友添加)
  *
- * @property userId 发送请求的 QQ 号
- * @property comment 验证信息
- * @property flag 请求 flag，在调用处理请求的 API 时需要传入
- *
- * @author ForteScarlet
+ * @property userId 新添加好友 QQ 号。
  */
+@ExpectEventType(
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "friend_add",
+)
 @Serializable
-@ExpectEventType(postType = RequestEvent.POST_TYPE, subType = "friend")
-public data class FriendRequestEvent(
+public data class RawFriendAddEvent(
     override val time: Long,
-    @SerialName("request_type")
-    override val requestType: String,
     @SerialName("self_id")
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
+    @SerialName("notice_type")
+    override val noticeType: String,
     @SerialName("user_id")
     public val userId: LongID,
-    public val comment: String = "",
-    public val flag: String,
-) : RequestEvent
+) : RawNoticeEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent.kt
@@ -23,16 +23,17 @@ import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [好友添加](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#好友添加)
+ * [好友消息撤回](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#好友消息撤回)
  *
- * @property userId 新添加好友 QQ 号。
+ * @property userId 好友 QQ 号。
+ * @property messageId 被撤回的消息 ID。
  */
 @ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "friend_add",
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "friend_recall",
 )
 @Serializable
-public data class FriendAddEvent(
+public data class RawFriendRecallEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -42,4 +43,6 @@ public data class FriendAddEvent(
     override val noticeType: String,
     @SerialName("user_id")
     public val userId: LongID,
-) : NoticeEvent
+    @SerialName("message_id")
+    public val messageId: LongID,
+) : RawNoticeEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent.kt
@@ -25,20 +25,19 @@ import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [群成员减少](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群成员减少)
+ * [群管理员变动](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群管理员变动)
  *
- * @property subType 事件子类型，分别表示主动退群、成员被踢、登录号被踢。
- * 可能的值: `leave`、`kick`、`kick_me`
+ * @property subType 事件子类型，分别表示设置和取消管理员。
+ * 可能的值: `set`、`unset`
  * @property groupId 群号。
- * @property operatorId 操作者 QQ 号（如果是主动退群，则和 `user_id` 相同）。
- * @property userId 离开者 QQ 号。
+ * @property userId 管理员 QQ 号。
  */
 @ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "group_decrease",
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "group_admin",
 )
 @Serializable
-public data class GroupDecreaseEvent(
+public data class RawGroupAdminEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -50,8 +49,18 @@ public data class GroupDecreaseEvent(
     public val subType: String,
     @SerialName("group_id")
     public val groupId: LongID,
-    @SerialName("operator_id")
-    public val operatorId: LongID,
     @SerialName("user_id")
     public val userId: LongID,
-) : NoticeEvent
+) : RawNoticeEvent {
+    public companion object {
+        /**
+         * @see RawGroupAdminEvent.subType
+         */
+        public const val SUB_TYPE_SET: String = "set"
+
+        /**
+         * @see RawGroupAdminEvent.subType
+         */
+        public const val SUB_TYPE_UNSET: String = "unset"
+    }
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent.kt
@@ -17,25 +17,29 @@
 
 package love.forte.simbot.component.onebot.v11.event.notice
 
+import kotlin.Long
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [群文件上传](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群文件上传)
+ * [群禁言](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群禁言)
  *
+ * @property subType 事件子类型，分别表示禁言、解除禁言。
+ * 可能的值: `ban`、`lift_ban`
  * @property groupId 群号。
- * @property userId 发送者 QQ 号。
- * @property file 文件信息。
+ * @property operatorId 操作者 QQ 号。
+ * @property userId 被禁言 QQ 号。
+ * @property duration 禁言时长，单位秒。
  */
 @ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "group_upload",
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "group_ban",
 )
 @Serializable
-public data class GroupUploadEvent(
+public data class RawGroupBanEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -43,26 +47,25 @@ public data class GroupUploadEvent(
     override val postType: String,
     @SerialName("notice_type")
     override val noticeType: String,
+    @SerialName("sub_type")
+    public val subType: String,
     @SerialName("group_id")
     public val groupId: LongID,
+    @SerialName("operator_id")
+    public val operatorId: LongID,
     @SerialName("user_id")
     public val userId: LongID,
-    public val file: FileInfo,
-) : NoticeEvent {
+    public val duration: Long,
+) : RawNoticeEvent {
+    public companion object {
+        /**
+         * @see RawGroupBanEvent.subType
+         */
+        public const val SUB_TYPE_BAN: String = "ban"
 
-    /**
-     * [GroupUploadEvent] 中的 [文件信息][GroupUploadEvent.file]
-     *
-     * @property id 文件 ID
-     * @property name 文件名
-     * @property size 文件大小（字节数）
-     * @property busid busid（目前不清楚有什么作用）
-     */
-    @Serializable
-    public data class FileInfo(
-        val id: ID,
-        val name: String,
-        val size: Long,
-        val busid: Long,
-    )
+        /**
+         * @see RawGroupBanEvent.subType
+         */
+        public const val SUB_TYPE_LIFT_BAN: String = "lift_ban"
+    }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent.kt
@@ -15,35 +15,43 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.meta
+package love.forte.simbot.component.onebot.v11.event.notice
 
+import kotlin.Long
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.LongID
-import love.forte.simbot.component.onebot.v11.common.api.StatusResult
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
-
 /**
- * [心跳](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#心跳)
+ * [群成员减少](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群成员减少)
  *
- * > 其中 `status` 字段的内容和 `get_status` 接口的快速操作相同。
- *
- * @property status 状态信息
- * @property interval 到下次心跳的间隔，单位毫秒
- *
- * @author ForteScarlet
+ * @property subType 事件子类型，分别表示主动退群、成员被踢、登录号被踢。
+ * 可能的值: `leave`、`kick`、`kick_me`
+ * @property groupId 群号。
+ * @property operatorId 操作者 QQ 号（如果是主动退群，则和 `user_id` 相同）。
+ * @property userId 离开者 QQ 号。
  */
+@ExpectEventType(
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "group_decrease",
+)
 @Serializable
-@ExpectEventType(postType = MetaEvent.POST_TYPE, subType = "heartbeat")
-public data class HeartbeatEvent(
+public data class RawGroupDecreaseEvent(
     override val time: Long,
-    @SerialName("meta_event_type")
-    override val metaEventType: String,
     @SerialName("self_id")
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
-    public val status: StatusResult,
-    public val interval: Long,
-) : MetaEvent
+    @SerialName("notice_type")
+    override val noticeType: String,
+    @SerialName("sub_type")
+    public val subType: String,
+    @SerialName("group_id")
+    public val groupId: LongID,
+    @SerialName("operator_id")
+    public val operatorId: LongID,
+    @SerialName("user_id")
+    public val userId: LongID,
+) : RawNoticeEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent.kt
@@ -25,28 +25,20 @@ import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [群成员荣誉变更](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群成员荣誉变更)、
- * [群红包运气王](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群红包运气王)、
- * [群内戳一戳](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群内戳一戳)。
+ * [群成员增加](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群成员增加)
  *
- * 其中，红包和戳一戳的 [subType] 分别为 `lucky_king` 和 `poke`
- *
- * @property subType 提示类型。
- * 可能的值: `honor`, `lucky_king`, `poke`
+ * @property subType 事件子类型，分别表示管理员已同意入群、管理员邀请入群。
+ * 可能的值: `approve`、`invite`
  * @property groupId 群号。
- * @property honorType 荣誉类型，分别表示龙王、群聊之火、快乐源泉。
- * 可能的值: `talkative`、`performer`、`emotion`。
- * 当 [subType] 为 `honor` 时有值。
- * @property userId 成员 QQ 号。
- * @property targetId 当 [subType] 为 `lucky_king` 时代表人气王用户ID，
- * 为 `poke` 时代表被戳的人的ID，否则为 `null`。
+ * @property operatorId 操作者 QQ 号。
+ * @property userId 加入者 QQ 号。
  */
 @ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "notify",
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "group_increase",
 )
 @Serializable
-public data class NotifyEvent(
+public data class RawGroupIncreaseEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -58,28 +50,8 @@ public data class NotifyEvent(
     public val subType: String,
     @SerialName("group_id")
     public val groupId: LongID,
-    @SerialName("honor_type")
-    public val honorType: String? = null,
+    @SerialName("operator_id")
+    public val operatorId: LongID,
     @SerialName("user_id")
     public val userId: LongID,
-    @SerialName("target_id")
-    public val targetId: LongID? = null
-) : NoticeEvent {
-    public companion object {
-        /**
-         * @see NotifyEvent.subType
-         */
-        public const val SUB_TYPE_HONOR: String = "honor"
-
-        /**
-         * @see NotifyEvent.subType
-         */
-        public const val SUB_TYPE_POKE: String = "poke"
-
-        /**
-         * @see NotifyEvent.subType
-         */
-        public const val SUB_TYPE_LUCKY_KING: String = "lucky_king"
-    }
-
-}
+) : RawNoticeEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent.kt
@@ -15,32 +15,42 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.meta
+package love.forte.simbot.component.onebot.v11.event.notice
 
+import kotlin.Long
+import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [生命周期](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md#生命周期)
+ * [群消息撤回](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群消息撤回)
  *
- *
- * @property subType 事件子类型，分别表示 OneBot 启用、停用、WebSocket 连接成功.
- * 可能的值: `enable`、`disable`、`connect`.
- * 注意，目前生命周期元事件中，只有 HTTP POST 的情况下可以收到 `enable` 和 `disable`，
- * 只有正向 WebSocket 和反向 WebSocket 可以收到 `connect`。
+ * @property groupId 群号。
+ * @property userId 消息发送者 QQ 号。
+ * @property operatorId 操作者 QQ 号。
+ * @property messageId 被撤回的消息 ID。
  */
+@ExpectEventType(
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "group_recall",
+)
 @Serializable
-@ExpectEventType(postType = MetaEvent.POST_TYPE, subType = "lifecycle")
-public data class LifecycleEvent(
+public data class RawGroupRecallEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
-    @SerialName("meta_event_type")
-    override val metaEventType: String,
-    @SerialName("sub_type")
-    public val subType: String,
-) : MetaEvent
+    @SerialName("notice_type")
+    override val noticeType: String,
+    @SerialName("group_id")
+    public val groupId: LongID,
+    @SerialName("user_id")
+    public val userId: LongID,
+    @SerialName("operator_id")
+    public val operatorId: LongID,
+    @SerialName("message_id")
+    public val messageId: LongID,
+) : RawNoticeEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent.kt
@@ -17,29 +17,25 @@
 
 package love.forte.simbot.component.onebot.v11.event.notice
 
-import kotlin.Long
-import kotlin.String
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import love.forte.simbot.common.id.ID
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [群禁言](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群禁言)
+ * [群文件上传](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群文件上传)
  *
- * @property subType 事件子类型，分别表示禁言、解除禁言。
- * 可能的值: `ban`、`lift_ban`
  * @property groupId 群号。
- * @property operatorId 操作者 QQ 号。
- * @property userId 被禁言 QQ 号。
- * @property duration 禁言时长，单位秒。
+ * @property userId 发送者 QQ 号。
+ * @property file 文件信息。
  */
 @ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "group_ban",
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "group_upload",
 )
 @Serializable
-public data class GroupBanEvent(
+public data class RawGroupUploadEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -47,25 +43,26 @@ public data class GroupBanEvent(
     override val postType: String,
     @SerialName("notice_type")
     override val noticeType: String,
-    @SerialName("sub_type")
-    public val subType: String,
     @SerialName("group_id")
     public val groupId: LongID,
-    @SerialName("operator_id")
-    public val operatorId: LongID,
     @SerialName("user_id")
     public val userId: LongID,
-    public val duration: Long,
-) : NoticeEvent {
-    public companion object {
-        /**
-         * @see GroupBanEvent.subType
-         */
-        public const val SUB_TYPE_BAN: String = "ban"
+    public val file: FileInfo,
+) : RawNoticeEvent {
 
-        /**
-         * @see GroupBanEvent.subType
-         */
-        public const val SUB_TYPE_LIFT_BAN: String = "lift_ban"
-    }
+    /**
+     * [RawGroupUploadEvent] 中的 [文件信息][RawGroupUploadEvent.file]
+     *
+     * @property id 文件 ID
+     * @property name 文件名
+     * @property size 文件大小（字节数）
+     * @property busid busid（目前不清楚有什么作用）
+     */
+    @Serializable
+    public data class FileInfo(
+        val id: ID,
+        val name: String,
+        val size: Long,
+        val busid: Long,
+    )
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent.kt
@@ -15,32 +15,25 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.meta
+package love.forte.simbot.component.onebot.v11.event.notice
 
-import love.forte.simbot.component.onebot.v11.event.Event
+import love.forte.simbot.component.onebot.v11.event.RawEvent
 import love.forte.simbot.component.onebot.v11.event.ExpectEventSubTypeProperty
 
 
 /**
- *
- * [元事件](https://github.com/botuniverse/onebot-11/blob/master/event/meta.md)
- *
- * > 消息、通知、请求三大类事件是与聊天软件直接相关的、机器人真实接收到的事件，
- * 除了这些，OneBot 自己还会产生一类事件，这里称之为「元事件」，
- * 例如生命周期事件、心跳事件等，这类事件与 OneBot 本身的运行状态有关，
- * 而与聊天软件无关。元事件的上报方式和普通事件完全一样。
+ * [通知事件](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md)
  *
  * @author ForteScarlet
  */
-@ExpectEventSubTypeProperty(value = "metaEventType", postType = MetaEvent.POST_TYPE, name = "meta_event_type")
-public interface MetaEvent : Event {
+@ExpectEventSubTypeProperty(value = "noticeType", postType = RawNoticeEvent.POST_TYPE, name = "notice_type")
+public interface RawNoticeEvent : RawEvent {
     /**
-     * 元事件类型
+     * 通知类型
      */
-    public val metaEventType: String
+    public val noticeType: String
 
     public companion object {
-        public const val POST_TYPE: String = "meta_event"
+        public const val POST_TYPE: String = "notice"
     }
 }
-

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent.kt
@@ -25,20 +25,28 @@ import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 /**
- * [群成员增加](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群成员增加)
+ * [群成员荣誉变更](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群成员荣誉变更)、
+ * [群红包运气王](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群红包运气王)、
+ * [群内戳一戳](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#群内戳一戳)。
  *
- * @property subType 事件子类型，分别表示管理员已同意入群、管理员邀请入群。
- * 可能的值: `approve`、`invite`
+ * 其中，红包和戳一戳的 [subType] 分别为 `lucky_king` 和 `poke`
+ *
+ * @property subType 提示类型。
+ * 可能的值: `honor`, `lucky_king`, `poke`
  * @property groupId 群号。
- * @property operatorId 操作者 QQ 号。
- * @property userId 加入者 QQ 号。
+ * @property honorType 荣誉类型，分别表示龙王、群聊之火、快乐源泉。
+ * 可能的值: `talkative`、`performer`、`emotion`。
+ * 当 [subType] 为 `honor` 时有值。
+ * @property userId 成员 QQ 号。
+ * @property targetId 当 [subType] 为 `lucky_king` 时代表人气王用户ID，
+ * 为 `poke` 时代表被戳的人的ID，否则为 `null`。
  */
 @ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "group_increase",
+    postType = RawNoticeEvent.POST_TYPE,
+    subType = "notify",
 )
 @Serializable
-public data class GroupIncreaseEvent(
+public data class RawNotifyEvent(
     override val time: Long,
     @SerialName("self_id")
     override val selfId: LongID,
@@ -50,8 +58,28 @@ public data class GroupIncreaseEvent(
     public val subType: String,
     @SerialName("group_id")
     public val groupId: LongID,
-    @SerialName("operator_id")
-    public val operatorId: LongID,
+    @SerialName("honor_type")
+    public val honorType: String? = null,
     @SerialName("user_id")
     public val userId: LongID,
-) : NoticeEvent
+    @SerialName("target_id")
+    public val targetId: LongID? = null
+) : RawNoticeEvent {
+    public companion object {
+        /**
+         * @see RawNotifyEvent.subType
+         */
+        public const val SUB_TYPE_HONOR: String = "honor"
+
+        /**
+         * @see RawNotifyEvent.subType
+         */
+        public const val SUB_TYPE_POKE: String = "poke"
+
+        /**
+         * @see RawNotifyEvent.subType
+         */
+        public const val SUB_TYPE_LUCKY_KING: String = "lucky_king"
+    }
+
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent.kt
@@ -24,11 +24,8 @@ import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
 
 /**
- * [加群请求／邀请](https://github.com/botuniverse/onebot-11/blob/master/event/request.md#加群请求邀请)
+ * [加好友请求](https://github.com/botuniverse/onebot-11/blob/master/event/request.md#加好友请求)
  *
- * @property subType 请求子类型，分别表示加群请求、邀请登录号入群。
- * 可能：`add`、`invite`
- * @property groupId 群号
  * @property userId 发送请求的 QQ 号
  * @property comment 验证信息
  * @property flag 请求 flag，在调用处理请求的 API 时需要传入
@@ -36,8 +33,8 @@ import love.forte.simbot.component.onebot.v11.event.ExpectEventType
  * @author ForteScarlet
  */
 @Serializable
-@ExpectEventType(postType = RequestEvent.POST_TYPE, subType = "group")
-public data class GroupRequestEvent(
+@ExpectEventType(postType = RawRequestEvent.POST_TYPE, subType = "friend")
+public data class RawFriendRequestEvent(
     override val time: Long,
     @SerialName("request_type")
     override val requestType: String,
@@ -45,25 +42,8 @@ public data class GroupRequestEvent(
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
-    @SerialName("sub_type")
-    public val subType: String,
-    @SerialName("group_id")
-    public val groupId: LongID,
     @SerialName("user_id")
     public val userId: LongID,
     public val comment: String = "",
     public val flag: String,
-) : RequestEvent {
-
-    public companion object {
-        /**
-         * @see GroupRequestEvent.subType
-         */
-        public const val SUB_TYPE_ADD: String = "add"
-
-        /**
-         * @see GroupRequestEvent.subType
-         */
-        public const val SUB_TYPE_INVITE: String = "invite"
-    }
-}
+) : RawRequestEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent.kt
@@ -15,34 +15,55 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.event.notice
+package love.forte.simbot.component.onebot.v11.event.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import love.forte.simbot.common.id.LongID
 import love.forte.simbot.component.onebot.v11.event.ExpectEventType
 
+
 /**
- * [好友消息撤回](https://github.com/botuniverse/onebot-11/blob/master/event/notice.md#好友消息撤回)
+ * [加群请求／邀请](https://github.com/botuniverse/onebot-11/blob/master/event/request.md#加群请求邀请)
  *
- * @property userId 好友 QQ 号。
- * @property messageId 被撤回的消息 ID。
+ * @property subType 请求子类型，分别表示加群请求、邀请登录号入群。
+ * 可能：`add`、`invite`
+ * @property groupId 群号
+ * @property userId 发送请求的 QQ 号
+ * @property comment 验证信息
+ * @property flag 请求 flag，在调用处理请求的 API 时需要传入
+ *
+ * @author ForteScarlet
  */
-@ExpectEventType(
-    postType = NoticeEvent.POST_TYPE,
-    subType = "friend_recall",
-)
 @Serializable
-public data class FriendRecallEvent(
+@ExpectEventType(postType = RawRequestEvent.POST_TYPE, subType = "group")
+public data class RawGroupRequestEvent(
     override val time: Long,
+    @SerialName("request_type")
+    override val requestType: String,
     @SerialName("self_id")
     override val selfId: LongID,
     @SerialName("post_type")
     override val postType: String,
-    @SerialName("notice_type")
-    override val noticeType: String,
+    @SerialName("sub_type")
+    public val subType: String,
+    @SerialName("group_id")
+    public val groupId: LongID,
     @SerialName("user_id")
     public val userId: LongID,
-    @SerialName("message_id")
-    public val messageId: LongID,
-) : NoticeEvent
+    public val comment: String = "",
+    public val flag: String,
+) : RawRequestEvent {
+
+    public companion object {
+        /**
+         * @see RawGroupRequestEvent.subType
+         */
+        public const val SUB_TYPE_ADD: String = "add"
+
+        /**
+         * @see RawGroupRequestEvent.subType
+         */
+        public const val SUB_TYPE_INVITE: String = "invite"
+    }
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/request/RawRequestEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/request/RawRequestEvent.kt
@@ -17,7 +17,7 @@
 
 package love.forte.simbot.component.onebot.v11.event.request
 
-import love.forte.simbot.component.onebot.v11.event.Event
+import love.forte.simbot.component.onebot.v11.event.RawEvent
 import love.forte.simbot.component.onebot.v11.event.ExpectEventSubTypeProperty
 
 
@@ -26,8 +26,8 @@ import love.forte.simbot.component.onebot.v11.event.ExpectEventSubTypeProperty
  *
  * @author ForteScarlet
  */
-@ExpectEventSubTypeProperty(value = "requestType", postType = RequestEvent.POST_TYPE, name = "request_type")
-public interface RequestEvent : Event {
+@ExpectEventSubTypeProperty(value = "requestType", postType = RawRequestEvent.POST_TYPE, name = "request_type")
+public interface RawRequestEvent : RawEvent {
     /**
      * 请求类型
      */


### PR DESCRIPTION
为了避免与simbot标准API中的事件类型产生混淆，趁早改

这是一个不兼容变更。