### PR TITLE
优化遇到未知事件时的处理逻辑与错误提示

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/UnknownEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/UnknownEvent.kt
@@ -26,6 +26,8 @@ import love.forte.simbot.common.id.LongID
  * 当出现了尚未支持或某种未知的事件体，无法对应到任何现有的已定义结构时，
  * 则应当将其解析并包装为 [UnknownEvent]。
  *
+ * [UnknownEvent] 要求事件体必须包括 [time], [selfId] 和 [postType]。
+ *
  * ### FragileAPI
  *
  * 这是一个具有**特殊规则**的事件类型。


### PR DESCRIPTION
现在如果不存在预期的 `sub_type` 也会直接转为 `UnknownEvent` 了 