### PR TITLE
OneBot配置中支持配置默认的 ImageAdditional 属性

### DIFF
--- a/Writerside/topics/onebot11-bot-config.md
+++ b/Writerside/topics/onebot11-bot-config.md
@@ -1,7 +1,5 @@
 # Bot配置文件
 
-<warning>TODO</warning>
-
 Bot配置文件通常情况下是配合Spring Boot starter的时候用的。
 
 当使用Spring Boot starter时，
@@ -19,33 +17,45 @@ Bot配置文件通常情况下是配合Spring Boot starter的时候用的。
 
 ```json
 {
-  // 固定值
-  "component": "simbot.onebot11",
-  "authorization": {
-    // 唯一ID，作为组件内 Bot 的 id，用于组件内去重。可以随便编，但建议是bot的qq号
-    "botUniqueId": "123456",
-    // api地址，是个http/https服务器的路径，默认localhost:3000
-    "apiServerHost": "http://localhost:3000",
-    // 订阅事件的服务器地址，是个ws/wss路径，默认localhost:3001
-    "eventServerHost":"ws://localhost:3001",
-    // 配置的 token，可以是null
-    "accessToken": null 
-  },
-  // 额外的可选配置
-  // config本身以及其内的各项属性绝大多数都可省略或null
-  "config": { 
-    // API请求中的超时请求配置。整数数字，单位毫秒，默认为 `null`。
-    "apiHttpRequestTimeoutMillis": null,
-    // API请求中的超时请求配置。整数数字，单位毫秒，默认为 `null`。
-    "apiHttpConnectTimeoutMillis": null,
-    // API请求中的超时请求配置。整数数字，单位毫秒，默认为 `null`。
-    "apiHttpSocketTimeoutMillis": null,
-    // 每次尝试连接到 ws 服务时的最大重试次数，大于等于0的整数，默认为 2147483647
-    "wsConnectMaxRetryTimes": null,
-    // 每次尝试连接到 ws 服务时，如果需要重新尝试，则每次尝试之间的等待时长
-    // 整数数字，单位毫秒，默认为 3500
-    "wsConnectRetryDelayMillis": null,
-  }
+    // 固定值
+    "component": "simbot.onebot11",
+    "authorization": {
+        // 唯一ID，作为组件内 Bot 的 id，用于组件内去重。可以随便编，但建议是bot的qq号
+        "botUniqueId": "123456",
+        // api地址，是个http/https服务器的路径，默认localhost:3000
+        "apiServerHost": "http://localhost:3000",
+        // 订阅事件的服务器地址，是个ws/wss路径，默认localhost:3001
+        "eventServerHost": "ws://localhost:3001",
+        // 配置的 token，可以是null
+        "accessToken": null
+    },
+    // 额外的可选配置
+    // config本身以及其内的各项属性绝大多数都可省略或null
+    "config": {
+        // API请求中的超时请求配置。整数数字，单位毫秒，默认为 `null`。
+        "apiHttpRequestTimeoutMillis": null,
+        // API请求中的超时请求配置。整数数字，单位毫秒，默认为 `null`。
+        "apiHttpConnectTimeoutMillis": null,
+        // API请求中的超时请求配置。整数数字，单位毫秒，默认为 `null`。
+        "apiHttpSocketTimeoutMillis": null,
+        // 每次尝试连接到 ws 服务时的最大重试次数，大于等于0的整数，默认为 2147483647
+        "wsConnectMaxRetryTimes": null,
+        // 每次尝试连接到 ws 服务时，如果需要重新尝试，则每次尝试之间的等待时长
+        // 整数数字，单位毫秒，默认为 3500
+        "wsConnectRetryDelayMillis": null,
+        // 当使用非 [OneBotImage] 类型作为图片资源发送消息时，
+        // 默认根据 [Resource] 得到一个可能存在的 [OneBotImage.AdditionalParams]。
+        // 注意！这无法影响直接使用 [OneBotImage] 的情况。
+        // defaultImageAdditionalParams 默认为 `null`。
+        "defaultImageAdditionalParams": {
+            // default: null
+            "localFileToBase64": null,
+            "type": null,
+            "cache": null,
+            "proxy": null,
+            "timeout": null
+        }
+    }
 }
 ```
 
@@ -66,3 +76,6 @@ Bot配置文件通常情况下是配合Spring Boot starter的时候用的。
 </tab>
 </tabs>
 
+## 属性说明
+
+<warning>TODO</warning>

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -41,7 +41,7 @@ object P {
         override val homepage: String get() = HOMEPAGE
 
 
-        private val baseVersion = v(0, 7, 0)
+        private val baseVersion = v(0, 8, 0)
 
         val snapshotVersion = baseVersion - Version.SNAPSHOT
         override val version = if (isSnapshot()) snapshotVersion else baseVersion

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/OneBot11Usage.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/OneBot11Usage.kt
@@ -120,12 +120,12 @@ private class OneBot11UsageBuilderImpl : OneBot11UsageBuilder {
  * @throws [NoSuchElementException] if no such element is found.
  */
 @OptIn(ExperimentalContracts::class)
-public inline fun Application.oneBot11Bots(block: OneBotBotManager.() -> Unit) {
+public inline fun <T> Application.oneBot11Bots(block: OneBotBotManager.() -> T): T {
     contract {
         callsInPlace(block, InvocationKind.EXACTLY_ONCE)
     }
 
-    botManagers.firstOneBotBotManager().block()
+    return botManagers.firstOneBotBotManager().block()
 }
 
 /**

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotFriendImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotFriendImpl.kt
@@ -26,12 +26,12 @@ import love.forte.simbot.component.onebot.v11.core.api.SendLikeApi
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
+import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateTextMsgApi
 import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
-import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 import kotlin.coroutines.CoroutineContext
@@ -60,7 +60,7 @@ internal abstract class OneBotFriendImpl : OneBotFriend {
     override suspend fun send(message: Message): OneBotMessageReceipt {
         return sendPrivateMsgApi(
             target = id,
-            message = message.resolveToOneBotSegmentList()
+            message = message.resolveToOneBotSegmentList(bot)
         ).requestDataBy(bot).toReceipt(bot)
     }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotGroupImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotGroupImpl.kt
@@ -30,11 +30,11 @@ import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.bot.requestResultBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
+import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupTextMsgApi
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
-import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 import kotlin.concurrent.Volatile
@@ -104,7 +104,7 @@ internal abstract class OneBotGroupImpl(
     override suspend fun send(message: Message): OneBotMessageReceipt {
         return sendGroupMsgApi(
             target = id,
-            message = message.resolveToOneBotSegmentList()
+            message = message.resolveToOneBotSegmentList(bot)
         ).requestDataBy(bot).toReceipt(bot)
     }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotMemberImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotMemberImpl.kt
@@ -29,13 +29,13 @@ import love.forte.simbot.component.onebot.v11.core.api.*
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
 import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
+import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateTextMsgApi
 import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
 import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
-import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 import kotlin.concurrent.Volatile
@@ -82,7 +82,7 @@ internal abstract class OneBotMemberImpl(
     override suspend fun send(message: Message): OneBotMessageReceipt {
         return sendPrivateMsgApi(
             target = id,
-            message = message.resolveToOneBotSegmentList()
+            message = message.resolveToOneBotSegmentList(bot)
         ).requestDataBy(bot).toReceipt(bot)
     }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration.kt
@@ -25,6 +25,9 @@ import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.overwriteWith
 import love.forte.simbot.common.function.ConfigurerFunction
 import love.forte.simbot.common.function.invokeBy
+import love.forte.simbot.component.onebot.common.annotations.ExperimentalOneBotAPI
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
+import love.forte.simbot.resource.Resource
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 
@@ -174,4 +177,27 @@ public class OneBotBotConfiguration {
      */
     public var wsConnectRetryDelayMillis: Long = 3500L
 
+    /**
+     * 当使用非 [OneBotImage] 类型作为图片资源发送消息时，
+     * 默认根据 [Resource] 得到一个可能存在的 [OneBotImage.AdditionalParams]。
+     * 注意！这无法影响直接使用 [OneBotImage] 的情况。
+     */
+    @ExperimentalOneBotAPI
+    public var defaultImageAdditionalParamsProvider: ((Resource) -> OneBotImage.AdditionalParams?)? = null
+
+    /**
+     * 配置 [defaultImageAdditionalParamsProvider]
+     */
+    @ExperimentalOneBotAPI
+    public fun defaultImageAdditionalParamsProvider(block: ((Resource) -> OneBotImage.AdditionalParams?)?) {
+        defaultImageAdditionalParamsProvider = block
+    }
+
+    /**
+     * 配置 [defaultImageAdditionalParamsProvider]
+     */
+    @ExperimentalOneBotAPI
+    public fun defaultImageAdditionalParams(params: OneBotImage.AdditionalParams?) {
+        defaultImageAdditionalParamsProvider = { params }
+    }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration.kt
@@ -23,6 +23,7 @@ import kotlinx.serialization.Serializable
 import love.forte.simbot.bot.SerializableBotConfiguration
 import love.forte.simbot.component.onebot.common.annotations.InternalOneBotAPI
 import love.forte.simbot.component.onebot.v11.core.component.OneBot11Component
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
 
 
 /**
@@ -69,8 +70,31 @@ public data class OneBotBotSerializableConfiguration(
         /**
          * @see OneBotBotConfiguration.wsConnectRetryDelayMillis
          */
-        val wsConnectRetryDelayMillis: Long? = null
+        val wsConnectRetryDelayMillis: Long? = null,
+
+        /**
+         * @see OneBotBotConfiguration.defaultImageAdditionalParams
+         */
+        val defaultImageAdditionalParams: AdditionalParams? = null,
     )
+
+    @Serializable
+    public data class AdditionalParams(
+        val localFileToBase64: Boolean = false,
+        val type: String? = null,
+        val cache: Boolean? = null,
+        val proxy: Boolean? = null,
+        val timeout: Int? = null,
+    ) {
+        internal fun resolve(): OneBotImage.AdditionalParams =
+            OneBotImage.AdditionalParams().apply {
+                localFileToBase64 = this@AdditionalParams.localFileToBase64
+                type = this@AdditionalParams.type
+                cache = this@AdditionalParams.cache
+                proxy = this@AdditionalParams.proxy
+                timeout = this@AdditionalParams.timeout
+            }
+    }
 
     public fun toConfiguration(): OneBotBotConfiguration =
         OneBotBotConfiguration().also { conf ->
@@ -85,6 +109,7 @@ public data class OneBotBotSerializableConfiguration(
                 apiHttpSocketTimeoutMillis?.also { conf.apiHttpSocketTimeoutMillis = it }
                 wsConnectMaxRetryTimes?.also { conf.wsConnectMaxRetryTimes = it }
                 wsConnectRetryDelayMillis?.also { conf.wsConnectRetryDelayMillis = it }
+                defaultImageAdditionalParams?.also { conf.defaultImageAdditionalParams(it.resolve()) }
             }
         }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
@@ -31,12 +31,12 @@ import love.forte.simbot.component.onebot.v11.core.event.message.OneBotNormalGro
 import love.forte.simbot.component.onebot.v11.core.event.message.OneBotNoticeGroupMessageEvent
 import love.forte.simbot.component.onebot.v11.core.internal.message.OneBotMessageContentImpl
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
+import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendGroupTextMsgApi
 import love.forte.simbot.component.onebot.v11.event.message.RawGroupMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
-import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 
@@ -87,7 +87,7 @@ internal abstract class OneBotGroupMessageEventImpl(
     override suspend fun reply(message: Message): OneBotMessageReceipt {
         return sendGroupMsgApi(
             target = sourceEvent.groupId,
-            message = message.resolveToOneBotSegmentList(),
+            message = message.resolveToOneBotSegmentList(bot),
             reply = sourceEvent.messageId
         ).requestDataBy(bot).toReceipt(bot)
     }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
@@ -32,12 +32,12 @@ import love.forte.simbot.component.onebot.v11.core.event.message.OneBotGroupPriv
 import love.forte.simbot.component.onebot.v11.core.event.message.OneBotPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.core.internal.message.OneBotMessageContentImpl
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
+import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateTextMsgApi
 import love.forte.simbot.component.onebot.v11.event.message.RawPrivateMessageEvent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
-import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.MessageContent
 
@@ -81,7 +81,7 @@ internal abstract class OneBotPrivateMessageEventImpl(
     override suspend fun reply(message: Message): OneBotMessageReceipt {
         return sendPrivateMsgApi(
             target = sourceEvent.userId,
-            message = message.resolveToOneBotSegmentList()
+            message = message.resolveToOneBotSegmentList(bot)
         ).requestDataBy(bot).toReceipt(bot)
     }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/utils/MessageResolvers.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/utils/MessageResolvers.kt
@@ -15,17 +15,15 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-package love.forte.simbot.component.onebot.v11.message
+package love.forte.simbot.component.onebot.v11.core.utils
 
-import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
+import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
+import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegment
-import love.forte.simbot.message.OfflineImageValueResolver
-import love.forte.simbot.resource.Resource
-import kotlin.coroutines.Continuation
+import love.forte.simbot.message.Message
 
-internal actual fun offlineImageResolver(
-    defaultImageAdditionalParams: ((Resource) -> OneBotImage.AdditionalParams?)?,
-): OfflineImageValueResolver<Continuation<OneBotMessageSegment?>> =
-    commonOfflineImageResolver(
-        defaultImageAdditionalParams = defaultImageAdditionalParams,
-    )
+internal suspend fun Message.resolveToOneBotSegmentList(
+    bot: OneBotBot,
+): List<OneBotMessageSegment> = resolveToOneBotSegmentList(
+    defaultImageAdditionalParams = bot.configuration.defaultImageAdditionalParamsProvider
+)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmTest/kotlin/BotDefaultImageAdditionalTests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmTest/kotlin/BotDefaultImageAdditionalTests.kt
@@ -1,0 +1,71 @@
+import kotlinx.coroutines.test.runTest
+import love.forte.simbot.component.onebot.v11.core.bot.firstOneBotBotManager
+import love.forte.simbot.component.onebot.v11.core.bot.register
+import love.forte.simbot.component.onebot.v11.core.useOneBot11
+import love.forte.simbot.component.onebot.v11.message.resolveToOneBotSegment
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
+import love.forte.simbot.core.application.launchSimpleApplication
+import love.forte.simbot.message.OfflineImage.Companion.toOfflineImage
+import love.forte.simbot.resource.toResource
+import java.nio.file.Files
+import kotlin.io.path.Path
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class BotDefaultImageAdditionalTests {
+
+    @Test
+    fun botDefaultImageAdditionalTest() = runTest {
+        val app = launchSimpleApplication {
+            useOneBot11()
+        }
+
+        val obm = app.botManagers.firstOneBotBotManager()
+        val bot1 = obm.register {
+            botUniqueId = "123"
+            defaultImageAdditionalParams(
+                OneBotImage.AdditionalParams().apply {
+                    localFileToBase64 = true
+                }
+            )
+        }
+        val bot2 = obm.register {
+            botUniqueId = "456"
+        }
+
+        val f = Files.createTempFile(
+            Path("."),
+            "temp",
+            "botDefaultImageAdditionalTestText",
+        )
+        f.toFile().deleteOnExit()
+        f.writeText("Hello")
+
+        val img = f.toResource().toOfflineImage()
+
+        val seg1 = img.resolveToOneBotSegment(
+            bot1.configuration.defaultImageAdditionalParamsProvider
+        )
+
+        assertIs<OneBotImage>(seg1)
+        assertTrue(seg1.data.file.startsWith("base64"))
+
+        val seg2 = img.resolveToOneBotSegment(
+            bot2.configuration.defaultImageAdditionalParamsProvider
+        )
+
+        assertIs<OneBotImage>(seg2)
+        assertEquals(f.absolutePathString(), seg2.data.file)
+
+    }
+
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/nativeMain/kotlin/love/forte/simbot/component/onebot/v11/message/MessageElementResolvers.native.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/nativeMain/kotlin/love/forte/simbot/component/onebot/v11/message/MessageElementResolvers.native.kt
@@ -17,9 +17,15 @@
 
 package love.forte.simbot.component.onebot.v11.message
 
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegment
 import love.forte.simbot.message.OfflineImageValueResolver
+import love.forte.simbot.resource.Resource
 import kotlin.coroutines.Continuation
 
-internal actual fun offlineImageResolver(): OfflineImageValueResolver<Continuation<OneBotMessageSegment?>> =
-    commonOfflineImageResolver()
+internal actual fun offlineImageResolver(
+    defaultImageAdditionalParams: ((Resource) -> OneBotImage.AdditionalParams?)?,
+): OfflineImageValueResolver<Continuation<OneBotMessageSegment?>> =
+    commonOfflineImageResolver(
+        defaultImageAdditionalParams = defaultImageAdditionalParams,
+    )


### PR DESCRIPTION
主要用来解决直接使用 OfflineImage 时，如果是本地文件则会直接使用绝对路径且难以配置的问题。

配置属性对直接使用 `OneBotImage` 时不起作用。