### PR TITLE
API请求时，如果 body 为 `null` 则默认填充空JSON字符串

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jsMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests.js.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jsMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests.js.kt
@@ -22,3 +22,4 @@ package love.forte.simbot.component.onebot.v11.core.api
  */
 @Suppress("TopLevelPropertyNaming")
 internal actual const val isContentNegotiationRuntimeAvailable: Boolean = true
+internal actual fun initConfig(key: String, default: String?): String? = default

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests.jvm.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests.jvm.kt
@@ -19,10 +19,9 @@
 
 package love.forte.simbot.component.onebot.v11.core.api
 
-import io.ktor.client.HttpClient
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.request
-import io.ktor.http.Url
+import io.ktor.client.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import io.ktor.utils.io.charsets.Charset
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.serialization.json.Json
@@ -34,6 +33,7 @@ import love.forte.simbot.suspendrunner.runInAsync
 import love.forte.simbot.suspendrunner.runInNoScopeBlocking
 import java.util.concurrent.CompletableFuture
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.text.Charsets
 
 /**
  * 校验当前运行时是否存在
@@ -554,3 +554,7 @@ public fun <T : Any> OneBotApi<T>.requestDataReserve(
         )
     }
 //endregion
+
+
+internal actual fun initConfig(key: String, default: String?): String? =
+    System.getProperty(key)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/nativeMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests.native.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/nativeMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests.native.kt
@@ -22,3 +22,4 @@ package love.forte.simbot.component.onebot.v11.core.api
  */
 @Suppress("TopLevelPropertyNaming")
 internal actual const val isContentNegotiationRuntimeAvailable: Boolean = true
+internal actual fun initConfig(key: String, default: String?): String? = default


### PR DESCRIPTION
为了兼容部分服务端。
可以通过 JVM 属性 `simbot.onebot11.api.request.emptyJsonStringIfBodyNull` 或 `GlobalOneBotApiRequestConfiguration.emptyJsonStringIfBodyNull` 修改。