### PR TITLE
RawGroupMessageEvent.Sender.level 类型变更为 `String`

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent.kt
@@ -98,7 +98,7 @@ public data class RawGroupMessageEvent @SourceEventConstructor constructor(
         override val age: Int = DEFAULT_AGE,
         public val card: String = "",
         public val area: String? = null,
-        public val level: Int? = null,
+        public val level: String? = null,
         public val role: String = "member",
         public val title: String? = null,
     ) : RawMessageEvent.Sender


### PR DESCRIPTION
fix #69