### PR TITLE
为 OneBotBot 追加实现 OneBotApiExecutable ，提供通过 `execute*` 直接执行 API 的能力

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,8 +108,6 @@ tasks.withType<Detekt>().configureEach {
 }
 
 apiValidation {
-    // TODO 都差不多的时候别忘了去掉
-    validationDisabled = true
     ignoredPackages.add("*.internal.*")
 
     this.ignoredProjects.addAll(

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -37,8 +37,8 @@ object P {
         override val description: String get() = DESCRIPTION
         override val homepage: String get() = HOMEPAGE
 
-        const val VERSION = "1.0.1"
-        const val NEXT_VERSION = "1.0.0"
+        const val VERSION = "1.1.0"
+        const val NEXT_VERSION = "1.1.1"
 
         override val snapshotVersion = "$NEXT_VERSION-SNAPSHOT"
         override val version = if (isSnapshot()) snapshotVersion else VERSION

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ ksp = "2.0.0-1.0.22"
 # https://square.github.io/kotlinpoet/
 kotlinPoet = "1.17.0"
 # https://mockk.io/
-mockk = "1.13.10"
+mockk = "1.13.12"
 # https://detekt.dev/docs/intro
 detekt = "1.23.3"
 

--- a/simbot-component-onebot-common/api/simbot-component-onebot-common.api
+++ b/simbot-component-onebot-common/api/simbot-component-onebot-common.api
@@ -1,0 +1,18 @@
+public abstract interface annotation class love/forte/simbot/component/onebot/common/annotations/ApiResultConstructor : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/component/onebot/common/annotations/ExperimentalOneBotAPI : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/component/onebot/common/annotations/InternalOneBotAPI : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/component/onebot/common/annotations/OneBotInternalImplementationsOnly : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class love/forte/simbot/component/onebot/common/annotations/SourceEventConstructor : java/lang/annotation/Annotation {
+}
+
+public abstract interface class love/forte/simbot/component/onebot/common/component/OneBotComponent : love/forte/simbot/component/Component {
+}
+

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-common/api/simbot-component-onebot-v11-common.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-common/api/simbot-component-onebot-v11-common.api
@@ -1,0 +1,28 @@
+public final class love/forte/simbot/component/onebot/v11/common/api/StatusResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/common/api/StatusResult$Companion;
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/Boolean;Z)Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;Ljava/lang/Boolean;ZILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGood ()Z
+	public final fun getOnline ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/common/api/StatusResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/common/api/StatusResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/common/api/StatusResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/api/simbot-component-onebot-v11-core.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/api/simbot-component-onebot-v11-core.api
@@ -1,0 +1,2640 @@
+public final class love/forte/simbot/component/onebot/v11/core/OneBot11 {
+	public static final field DefaultJson Lkotlinx/serialization/json/Json;
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/OneBot11;
+	public static final field serializersModule Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/OneBot11UsageBuilder {
+	public abstract fun botManager (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public abstract fun component (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/OneBot11UsageKt {
+	public static final fun oneBot11Bots (Llove/forte/simbot/application/Application;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun oneBot11BotsIfSupport (Llove/forte/simbot/application/Application;Lkotlin/jvm/functions/Function1;)V
+	public static final fun useOneBot11 (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun useOneBot11$default (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/actor/OneBotFriend : love/forte/simbot/component/onebot/v11/core/actor/OneBotStrangerAware, love/forte/simbot/component/onebot/v11/core/actor/SendLikeSupport, love/forte/simbot/definition/Contact {
+	public fun getAvatar ()Ljava/lang/String;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract synthetic fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/actor/OneBotGroup : love/forte/simbot/ability/DeleteSupport, love/forte/simbot/definition/ChatGroup {
+	public abstract synthetic fun ban (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun banAsync (Z)Ljava/util/concurrent/CompletableFuture;
+	public fun banBlocking (Z)V
+	public fun banReserve (Z)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun botAsMember (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getAllHonorInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getAllHonorInfo$suspendImpl (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAllHonorInfoAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getAllHonorInfoBlocking ()Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;
+	public fun getAllHonorInfoReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getBotAsMember ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getBotAsMember ()Llove/forte/simbot/definition/Member;
+	public fun getBotAsMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getBotAsMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract synthetic fun getHonorInfo (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getHonorInfoAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun getHonorInfoBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;
+	public fun getHonorInfoReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getMaxMemberCount ()I
+	public fun getMember (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getMember (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public abstract fun getMemberCount ()I
+	public fun getMemberReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMembers ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract fun getName ()Ljava/lang/String;
+	public fun getRoles ()Llove/forte/simbot/common/collectable/Collectable;
+	public abstract synthetic fun member (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setAdmin (Llove/forte/simbot/common/id/ID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setAdminAsync (Llove/forte/simbot/common/id/ID;Z)Ljava/util/concurrent/CompletableFuture;
+	public fun setAdminBlocking (Llove/forte/simbot/common/id/ID;Z)V
+	public fun setAdminReserve (Llove/forte/simbot/common/id/ID;Z)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setAnonymous (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setAnonymousAsync (Z)Ljava/util/concurrent/CompletableFuture;
+	public fun setAnonymousBlocking (Z)V
+	public fun setAnonymousReserve (Z)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setBotGroupNick (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setBotGroupNickAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun setBotGroupNickBlocking (Ljava/lang/String;)V
+	public fun setBotGroupNickReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setName (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setNameAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun setNameBlocking (Ljava/lang/String;)V
+	public fun setNameReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption : love/forte/simbot/ability/DeleteOption {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption$Companion;
+	public static final fun dismiss ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption$Dismiss;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption$Companion {
+	public final fun dismiss ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption$Dismiss;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption$Dismiss : love/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroupDeleteOption$Dismiss;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotGroupKt {
+	public static final synthetic fun ban (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun unban (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/actor/OneBotMember : love/forte/simbot/ability/DeleteSupport, love/forte/simbot/component/onebot/v11/core/actor/OneBotStrangerAware, love/forte/simbot/definition/Member {
+	public abstract synthetic fun ban (JLjava/util/concurrent/TimeUnit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun ban-VtjQ1oo (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun banAsync (JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/CompletableFuture;
+	public abstract fun banBlocking (JLjava/util/concurrent/TimeUnit;)V
+	public abstract fun banReserve (JLjava/util/concurrent/TimeUnit;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAvatar ()Ljava/lang/String;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getNick ()Ljava/lang/String;
+	public abstract fun getRole ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+	public abstract synthetic fun getSourceMemberInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getSourceMemberInfoAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceMemberInfoBlocking ()Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult;
+	public fun getSourceMemberInfoReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun send (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun send (Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendAsync (Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Ljava/lang/String;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun sendBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/message/MessageReceipt;
+	public fun sendReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun sendReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setAdmin (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setAdminAsync (Z)Ljava/util/concurrent/CompletableFuture;
+	public fun setAdminBlocking (Z)V
+	public fun setAdminReserve (Z)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setNick (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setNickAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun setNickBlocking (Ljava/lang/String;)V
+	public fun setNickReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun setSpecialTitle (Ljava/lang/String;JLjava/util/concurrent/TimeUnit;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun setSpecialTitle (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun setSpecialTitle$default (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract synthetic fun setSpecialTitle-8Mi8wO0 (Ljava/lang/String;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setSpecialTitleAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public abstract fun setSpecialTitleAsync (Ljava/lang/String;JLjava/util/concurrent/TimeUnit;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun setSpecialTitleAsync$default (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun setSpecialTitleBlocking (Ljava/lang/String;)V
+	public abstract fun setSpecialTitleBlocking (Ljava/lang/String;JLjava/util/concurrent/TimeUnit;)V
+	public static synthetic fun setSpecialTitleBlocking$default (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;Ljava/lang/String;ILjava/lang/Object;)V
+	public fun setSpecialTitleReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun setSpecialTitleReserve (Ljava/lang/String;JLjava/util/concurrent/TimeUnit;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun setSpecialTitleReserve$default (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun unban (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unban$suspendImpl (Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unbanAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun unbanBlocking ()V
+	public fun unbanReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption : love/forte/simbot/ability/DeleteOption {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption$Companion;
+	public static final fun rejectRequest ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption$RejectRequest;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption$Companion {
+	public final fun rejectRequest ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption$RejectRequest;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption$RejectRequest : love/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberDeleteOption$RejectRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole : java/lang/Enum, love/forte/simbot/definition/Role {
+	public static final field ADMIN Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole$Companion;
+	public static final field MEMBER Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+	public static final field OWNER Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public synthetic fun getName ()Ljava/lang/String;
+	public fun isAdmin ()Z
+	public static fun valueOf (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+	public static final fun valueOfLenient (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+	public static fun values ()[Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole$Companion {
+	public final fun valueOfLenient (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMemberRole;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/actor/OneBotStranger : love/forte/simbot/definition/User {
+	public abstract fun getAge ()I
+	public fun getAvatar ()Ljava/lang/String;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getSex ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/actor/OneBotStrangerAware {
+	public abstract synthetic fun toStranger (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun toStrangerAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun toStrangerBlocking ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotStranger;
+	public fun toStrangerReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/actor/SendLikeSupport {
+	public abstract synthetic fun sendLike (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun sendLikeAsync (I)Ljava/util/concurrent/CompletableFuture;
+	public fun sendLikeBlocking (I)V
+	public fun sendLikeReserve (I)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendImageApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendImageApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendImageResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult$Companion;
+	public final fun component1 ()Z
+	public final fun copy (Z)Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult;ZILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getYes ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/CanSendImageResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/CanSendImageResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendImageResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendRecordApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendRecordApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult$Companion;
+	public final fun component1 ()Z
+	public final fun copy (Z)Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult;ZILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getYes ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CanSendRecordResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CleanCacheApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/CleanCacheApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/CleanCacheApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/CleanCacheApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/CleanCacheApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/DeleteMsgApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/DeleteMsgApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/DeleteMsgApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/DeleteMsgApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/DeleteMsgApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCookiesApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi;
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCookiesApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi;
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi$Factory;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCookiesResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCookies ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetCookiesResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCookiesResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi;
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi;
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi$Factory;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCookies ()Ljava/lang/String;
+	public final fun getCsrfToken ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult$Companion;
+	public final fun component1 ()I
+	public final fun copy (I)Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult;IILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getToken ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetForwardMsgApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetForwardMsgApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult$Companion;
+	public final fun component1 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetForwardMsgResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetFriendListApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetFriendListApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetFriendListResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getRemark ()Ljava/lang/String;
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetFriendListResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetFriendListResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetFriendListResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi$Factory;
+	public static final field TYPE_ALL Ljava/lang/String;
+	public static final field TYPE_EMOTION Ljava/lang/String;
+	public static final field TYPE_LEGEND Ljava/lang/String;
+	public static final field TYPE_PERFORMER Ljava/lang/String;
+	public static final field TYPE_STRONG_NEWBIE Ljava/lang/String;
+	public static final field TYPE_TALKATIVE Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi;
+	public static final fun createAll (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi;
+	public final fun createAll (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCurrentTalkative ()Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;
+	public final fun getEmotionList ()Ljava/util/List;
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getLegendList ()Ljava/util/List;
+	public final fun getPerformerList ()Ljava/util/List;
+	public final fun getStrongNewbieList ()Ljava/util/List;
+	public final fun getTalkativeList ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;I)V
+	public synthetic fun <init> (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;I)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvatar ()Ljava/lang/String;
+	public final fun getDayCount ()I
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$CurrentTalkative$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvatar ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupHonorInfoResult$HonorInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()I
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;II)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;IIILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getGroupName ()Ljava/lang/String;
+	public final fun getMaxMemberCount ()I
+	public final fun getMemberCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupInfoResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupListApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetGroupListApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetGroupListApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupListApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetGroupListApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Z
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()I
+	public final fun component15 ()Z
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;IZ)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;IZILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAge ()I
+	public final fun getArea ()Ljava/lang/String;
+	public final fun getCard ()Ljava/lang/String;
+	public final fun getCardChangeable ()Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getJoinTime ()I
+	public final fun getLastSentTime ()I
+	public final fun getLevel ()Ljava/lang/String;
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getSex ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTitleExpireTime ()I
+	public final fun getUnfriendly ()Z
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberInfoResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberListApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberListApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberListApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetGroupMemberListApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetGroupMemberListApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetImageApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetImageApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetImageApi$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetImageResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetImageResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetImageResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetLoginInfoApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetLoginInfoApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetMsgApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetMsgApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetMsgApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetMsgApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetMsgApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetMsgResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult$Companion;
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Llove/forte/simbot/common/id/IntID;
+	public final fun component4 ()Llove/forte/simbot/common/id/IntID;
+	public final fun component5 ()Lkotlinx/serialization/json/JsonObject;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (ILjava/lang/String;Llove/forte/simbot/common/id/IntID;Llove/forte/simbot/common/id/IntID;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult;ILjava/lang/String;Llove/forte/simbot/common/id/IntID;Llove/forte/simbot/common/id/IntID;Lkotlinx/serialization/json/JsonObject;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/util/List;
+	public final fun getMessageId ()Llove/forte/simbot/common/id/IntID;
+	public final fun getMessageType ()Ljava/lang/String;
+	public final fun getRealId ()Llove/forte/simbot/common/id/IntID;
+	public final fun getTime ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetMsgResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetMsgResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetMsgResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetRecordApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetRecordApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetRecordApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetRecordApi$Factory {
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetRecordApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetRecordResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetRecordResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetRecordResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetStatusApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetStatusApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetStatusApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetStatusApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetStatusApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;I)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAge ()I
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getSex ()Ljava/lang/String;
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetStrangerInfoResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetVersionInfoApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoApi$Factory;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetVersionInfoApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getAppVersion ()Ljava/lang/String;
+	public final fun getProtocolVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/GetVersionInfoResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public abstract fun getAction ()Ljava/lang/String;
+	public abstract fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public abstract fun getBody ()Ljava/lang/Object;
+	public abstract fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotApi$Actions {
+	public static final field ASYNC_SUFFIX Ljava/lang/String;
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi$Actions;
+	public static final field RATE_LIMITED_SUFFIX Ljava/lang/String;
+}
+
+public class love/forte/simbot/component/onebot/v11/core/api/OneBotApiException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable {
+	public abstract synthetic fun execute (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun executeAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Ljava/util/concurrent/CompletableFuture;
+	public fun executeBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Lio/ktor/client/statement/HttpResponse;
+	public abstract synthetic fun executeData (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun executeDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Ljava/util/concurrent/CompletableFuture;
+	public fun executeDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Ljava/lang/Object;
+	public fun executeDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun executeRaw (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun executeRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Ljava/util/concurrent/CompletableFuture;
+	public fun executeRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Ljava/lang/String;
+	public fun executeRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun executeReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun executeResult (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun executeResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Ljava/util/concurrent/CompletableFuture;
+	public fun executeResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public fun executeResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutableKt {
+	public static final fun inExecutableScope (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun withExecutableScope (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutableScope {
+	public static final synthetic fun box-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutableScope;
+	public static fun constructor-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;)Z
+	public static final fun execute-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun executeData-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun executeRaw-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun executeResult-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotApiRequests {
+	public static final fun getApiLogger ()Lorg/slf4j/Logger;
+	public static final synthetic fun request (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun request (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun request$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun request$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun requestBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun requestBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun requestBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun requestBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun requestBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Lio/ktor/client/statement/HttpResponse;
+	public static synthetic fun requestBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;ILjava/lang/Object;)Lio/ktor/client/statement/HttpResponse;
+	public static synthetic fun requestBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;ILjava/lang/Object;)Lio/ktor/client/statement/HttpResponse;
+	public static final synthetic fun requestData (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun requestData (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun requestData$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun requestData$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestDataAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestDataAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/lang/Object;
+	public static final fun requestDataBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;)Ljava/lang/Object;
+	public static synthetic fun requestDataBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun requestDataBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestDataReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestDataReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestDataReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final synthetic fun requestRaw (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun requestRaw (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun requestRaw$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun requestRaw$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestRawAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestRawAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Ljava/lang/String;
+	public static final fun requestRawBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/lang/String;
+	public static synthetic fun requestRawBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;ILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun requestRawBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestRawReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestRawReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestRawReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final synthetic fun requestResult (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun requestResult (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun requestResult$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun requestResult$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestResultAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun requestResultAsync$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static synthetic fun requestResultBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static synthetic fun requestResultBlocking$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun requestResultReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestResultReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Lio/ktor/http/Url;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun requestResultReserve$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Lio/ktor/client/HttpClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Collection;Ljava/nio/charset/Charset;Lkotlinx/coroutines/CoroutineScope;Lkotlinx/serialization/json/Json;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public class love/forte/simbot/component/onebot/v11/core/api/OneBotApiResponseNotSuccessException : love/forte/simbot/component/onebot/v11/core/api/OneBotApiException {
+	public fun <init> (Lio/ktor/http/HttpStatusCode;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Lio/ktor/http/HttpStatusCode;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getStatus ()Lio/ktor/http/HttpStatusCode;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotApiResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult$Companion;
+	public static final field RETCODE_ASYNC I
+	public static final field RETCODE_SUCCESS I
+	public fun <init> (ILjava/lang/String;Ljava/lang/Object;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun copy (ILjava/lang/String;Ljava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;ILjava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/Object;
+	public final fun getDataOrThrow ()Ljava/lang/Object;
+	public final fun getRaw ()Ljava/lang/String;
+	public final fun getRetcode ()I
+	public final fun getStatus ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isSuccess ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/OneBotApiResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public fun <init> (Lkotlinx/serialization/KSerializer;)V
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;)V
+	public final fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotApiResult$Companion {
+	public final fun emptySerializer ()Lkotlinx/serialization/KSerializer;
+	public final fun serializer (Lkotlinx/serialization/KSerializer;)Lkotlinx/serialization/KSerializer;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$Companion;
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;
+	public static final fun create (Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$Companion {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;
+	public final fun create (Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue : love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSegments ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$SegmentsValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue : love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing$StringValue$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoingSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoingSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendGroupMsgApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendLikeApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Integer;)Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendLikeApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Integer;)Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/Integer;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendLikeApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendMsgApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi$Factory;
+	public static final field MESSAGE_TYPE_GROUP Ljava/lang/String;
+	public static final field MESSAGE_TYPE_PRIVATE Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static final fun createGroup (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static final fun createGroup (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static final fun createPrivate (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static final fun createPrivate (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendMsgApi$Factory {
+	public final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi$Factory;Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public final fun createGroup (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public final fun createGroup (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static synthetic fun createGroup$default (Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public final fun createPrivate (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public final fun createPrivate (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+	public static synthetic fun createPrivate$default (Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendMsgResult {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/IntID;
+	public final fun copy (Llove/forte/simbot/common/id/IntID;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult;Llove/forte/simbot/common/id/IntID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageId ()Llove/forte/simbot/common/id/IntID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/api/SendMsgResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/api/SendMsgResult;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendMsgResult$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Z)Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;)Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;Z)Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/component/onebot/v11/core/api/OneBotMessageOutgoing;ZILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SendPrivateMsgApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+	public static final fun create (Ljava/lang/String;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+	public static final fun create (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+	public final fun create (Ljava/lang/String;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+	public final fun create (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi$Factory;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetFriendAddRequestApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi$Factory {
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi$Factory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAddRequestApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAdminApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupAnonymousBanApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Long;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupBanApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupCardApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupKickApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupLeaveApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupNameApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupNameApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupNameApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupNameApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupNameApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi$Factory;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupSpecialTitleApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi$Factory;Llove/forte/simbot/common/id/ID;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetGroupWholeBanApi;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetRestartApi : love/forte/simbot/component/onebot/v11/core/api/OneBotApi {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi$Factory;
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi;
+	public static final fun create (Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi;
+	public fun getAction ()Ljava/lang/String;
+	public fun getApiResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+	public fun getBody ()Ljava/lang/Object;
+	public fun getResultDeserializer ()Lkotlinx/serialization/DeserializationStrategy;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/api/SetRestartApi$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi;
+	public final fun create (Ljava/lang/Long;)Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi$Factory;Ljava/lang/Long;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/SetRestartApi;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/bot/OneBotBot : love/forte/simbot/bot/Bot, love/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable {
+	public synthetic fun getAccessToken ()Ljava/lang/String;
+	public abstract fun getApiAccessToken ()Ljava/lang/String;
+	public abstract fun getApiClient ()Lio/ktor/client/HttpClient;
+	public abstract fun getApiHost ()Lio/ktor/http/Url;
+	public abstract fun getConfiguration ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration;
+	public abstract fun getContactRelation ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotFriendRelation;
+	public abstract synthetic fun getCookies (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getCookies$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun getCookiesAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun getCookiesAsync$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun getCookiesBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;
+	public static synthetic fun getCookiesBlocking$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCookiesResult;
+	public fun getCookiesReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun getCookiesReserve$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public abstract synthetic fun getCredentials (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getCredentials$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun getCredentialsAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun getCredentialsAsync$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public fun getCredentialsBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;
+	public static synthetic fun getCredentialsBlocking$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/api/GetCredentialsResult;
+	public fun getCredentialsReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun getCredentialsReserve$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun getCsrfToken (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getCsrfTokenAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getCsrfTokenBlocking ()Llove/forte/simbot/component/onebot/v11/core/api/GetCsrfTokenResult;
+	public fun getCsrfTokenReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getDecoderJson ()Lkotlinx/serialization/json/Json;
+	public abstract fun getEventAccessToken ()Ljava/lang/String;
+	public abstract fun getGroupRelation ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotGroupRelation;
+	public fun getGuildRelation ()Llove/forte/simbot/bot/GuildRelation;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getUserId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun isMe (Llove/forte/simbot/common/id/ID;)Z
+	public abstract fun push (Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public fun pushAndLaunch (Ljava/lang/String;)Lkotlinx/coroutines/Job;
+	public abstract synthetic fun queryLoginInfo (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun queryLoginInfoAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun queryLoginInfoBlocking ()Llove/forte/simbot/component/onebot/v11/core/api/GetLoginInfoResult;
+	public fun queryLoginInfoReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun start (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration {
+	public fun <init> ()V
+	public final fun accessToken (Ljava/lang/String;)V
+	public final fun apiClientConfigurer (Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration;
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getApiAccessToken ()Ljava/lang/String;
+	public final fun getApiClientConfigurer ()Llove/forte/simbot/common/function/ConfigurerFunction;
+	public final fun getApiClientEngine ()Lio/ktor/client/engine/HttpClientEngine;
+	public final fun getApiClientEngineFactory ()Lio/ktor/client/engine/HttpClientEngineFactory;
+	public final fun getApiHttpConnectTimeoutMillis ()Ljava/lang/Long;
+	public final fun getApiHttpRequestTimeoutMillis ()Ljava/lang/Long;
+	public final fun getApiHttpSocketTimeoutMillis ()Ljava/lang/Long;
+	public final fun getApiServerHost ()Lio/ktor/http/Url;
+	public final fun getBotUniqueId ()Ljava/lang/String;
+	public final fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun getEventAccessToken ()Ljava/lang/String;
+	public final fun getEventServerHost ()Lio/ktor/http/Url;
+	public final fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+	public final fun getWsClientEngine ()Lio/ktor/client/engine/HttpClientEngine;
+	public final fun getWsClientEngineFactory ()Lio/ktor/client/engine/HttpClientEngineFactory;
+	public final fun getWsConnectMaxRetryTimes ()I
+	public final fun getWsConnectRetryDelayMillis ()J
+	public final fun setAccessToken (Ljava/lang/String;)V
+	public final fun setApiAccessToken (Ljava/lang/String;)V
+	public final fun setApiClientConfigurer (Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public final fun setApiClientEngine (Lio/ktor/client/engine/HttpClientEngine;)V
+	public final fun setApiClientEngineFactory (Lio/ktor/client/engine/HttpClientEngineFactory;)V
+	public final fun setApiHttpConnectTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setApiHttpRequestTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setApiHttpSocketTimeoutMillis (Ljava/lang/Long;)V
+	public final fun setApiServerHost (Lio/ktor/http/Url;)V
+	public final fun setApiServerHost (Ljava/lang/String;)V
+	public final fun setBotUniqueId (Ljava/lang/String;)V
+	public final fun setCoroutineContext (Lkotlin/coroutines/CoroutineContext;)V
+	public final fun setEventAccessToken (Ljava/lang/String;)V
+	public final fun setEventServerHost (Lio/ktor/http/Url;)V
+	public final fun setEventServerHost (Ljava/lang/String;)V
+	public final fun setSerializersModule (Lkotlinx/serialization/modules/SerializersModule;)V
+	public final fun setWsClientEngine (Lio/ktor/client/engine/HttpClientEngine;)V
+	public final fun setWsClientEngineFactory (Lio/ktor/client/engine/HttpClientEngineFactory;)V
+	public final fun setWsConnectMaxRetryTimes (I)V
+	public final fun setWsConnectRetryDelayMillis (J)V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotFriendRelation : love/forte/simbot/bot/ContactRelation {
+	public synthetic fun contact (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun contact$suspendImpl (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotFriendRelation;Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun contactCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun contactCount$suspendImpl (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotFriendRelation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getContact (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotFriend;
+	public synthetic fun getContact (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/Contact;
+	public fun getContactAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getContactReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getContacts ()Llove/forte/simbot/common/collectable/Collectable;
+	public fun getStranger (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotStranger;
+	public fun getStrangerAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getStrangerReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun stranger (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotGroupRelation : love/forte/simbot/bot/GroupRelation {
+	public fun getGroup (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getGroup (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/definition/ChatGroup;
+	public fun getGroupAsync (Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getGroupReserve (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getGroups ()Llove/forte/simbot/common/collectable/Collectable;
+	public fun getMember (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public fun getMemberAsync (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun group (Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun groupCount (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun groupCount$suspendImpl (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotGroupRelation;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun member (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager : love/forte/simbot/bot/JobBasedBotManager, love/forte/simbot/bot/BotManager {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager$Factory;
+	public fun <init> ()V
+	public abstract fun all ()Lkotlin/sequences/Sequence;
+	public fun configurable (Llove/forte/simbot/bot/SerializableBotConfiguration;)Z
+	public abstract fun find (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+	public abstract fun get (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+	public synthetic fun register (Llove/forte/simbot/bot/SerializableBotConfiguration;)Llove/forte/simbot/bot/Bot;
+	public fun register (Llove/forte/simbot/bot/SerializableBotConfiguration;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+	public abstract fun register (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager$Factory : love/forte/simbot/bot/BotManagerFactory {
+	public synthetic fun create (Ljava/lang/Object;Llove/forte/simbot/common/function/ConfigurerFunction;)Ljava/lang/Object;
+	public fun create (Llove/forte/simbot/plugin/PluginConfigureContext;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager;
+	public synthetic fun getKey ()Llove/forte/simbot/common/function/MergeableFactory$Key;
+	public fun getKey ()Llove/forte/simbot/plugin/PluginFactory$Key;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManagerConfiguration {
+	public fun <init> ()V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManagerFactoryConfigurerProvider : love/forte/simbot/plugin/PluginFactoryConfigurerProvider {
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManagerFactoryProvider : love/forte/simbot/plugin/PluginFactoryProvider {
+	public fun <init> ()V
+	public fun loadConfigures ()Lkotlin/sequences/Sequence;
+	public fun provide ()Llove/forte/simbot/plugin/PluginFactory;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManagerKt {
+	public static final fun register (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotManagerUsageKt {
+	public static final fun filterIsOneBotBotManagers (Ljava/lang/Iterable;)Ljava/util/List;
+	public static final fun filterIsOneBotBotManagers (Lkotlin/sequences/Sequence;)Lkotlin/sequences/Sequence;
+	public static final fun firstOneBotBotManager (Ljava/lang/Iterable;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager;
+	public static final fun firstOneBotBotManager (Lkotlin/sequences/Sequence;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager;
+	public static final fun firstOneBotBotManagerOrNull (Ljava/lang/Iterable;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager;
+	public static final fun firstOneBotBotManagerOrNull (Lkotlin/sequences/Sequence;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotManager;
+	public static final fun useOneBot11BotManager (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public static synthetic fun useOneBot11BotManager$default (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotRequests {
+	public static final synthetic fun requestBy (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun requestByAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestByBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun requestByReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final synthetic fun requestDataBy (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun requestDataByAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestDataByBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/lang/Object;
+	public static final fun requestDataByReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final synthetic fun requestRawBy (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun requestRawByAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestRawByBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/lang/String;
+	public static final fun requestRawByReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final synthetic fun requestResultBy (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun requestResultByAsync (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun requestResultByBlocking (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/component/onebot/v11/core/api/OneBotApiResult;
+	public static final fun requestResultByReserve (Llove/forte/simbot/component/onebot/v11/core/api/OneBotApi;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLjava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;ZLjava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getLocalFileToBase64 ()Z
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getApiAccessToken ()Ljava/lang/String;
+	public final fun getApiServerHost ()Ljava/lang/String;
+	public final fun getBotUniqueId ()Ljava/lang/String;
+	public final fun getEventAccessToken ()Ljava/lang/String;
+	public final fun getEventServerHost ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Authorization$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Integer;Ljava/lang/Long;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApiHttpConnectTimeoutMillis ()Ljava/lang/Long;
+	public final fun getApiHttpRequestTimeoutMillis ()Ljava/lang/Long;
+	public final fun getApiHttpSocketTimeoutMillis ()Ljava/lang/Long;
+	public final fun getDefaultImageAdditionalParams ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$AdditionalParams;
+	public final fun getWsConnectMaxRetryTimes ()Ljava/lang/Integer;
+	public final fun getWsConnectRetryDelayMillis ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/OneBotBotSerializableConfiguration$Config$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotManagerImpl$inlined$sam$i$java_util_function_BiFunction$0 : java/util/function/BiFunction {
+	public fun <init> (Lkotlin/jvm/functions/Function2;)V
+	public final synthetic fun apply (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/component/OneBot11Component : love/forte/simbot/component/onebot/common/component/OneBotComponent {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/core/component/OneBot11Component$Factory;
+	public static final field ID_VALUE Ljava/lang/String;
+	public static final field SerializersModule Lkotlinx/serialization/modules/SerializersModule;
+	public fun <init> ()V
+	public fun getId ()Ljava/lang/String;
+	public fun getSerializersModule ()Lkotlinx/serialization/modules/SerializersModule;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/component/OneBot11Component$Factory : love/forte/simbot/component/ComponentFactory {
+	public synthetic fun create (Ljava/lang/Object;Llove/forte/simbot/common/function/ConfigurerFunction;)Ljava/lang/Object;
+	public fun create (Llove/forte/simbot/component/ComponentConfigureContext;Llove/forte/simbot/common/function/ConfigurerFunction;)Llove/forte/simbot/component/onebot/v11/core/component/OneBot11Component;
+	public synthetic fun getKey ()Llove/forte/simbot/common/function/MergeableFactory$Key;
+	public fun getKey ()Llove/forte/simbot/component/ComponentFactory$Key;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/component/OneBot11ComponentConfiguration {
+	public fun <init> ()V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/component/OneBot11ComponentFactoryConfigurerProvider : love/forte/simbot/component/ComponentFactoryConfigurerProvider {
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/component/OneBot11ComponentFactoryProvider : love/forte/simbot/component/ComponentFactoryProvider {
+	public fun <init> ()V
+	public fun loadConfigures ()Lkotlin/sequences/Sequence;
+	public fun provide ()Llove/forte/simbot/component/ComponentFactory;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/component/OneBot11ComponentUsage {
+	public static final fun useOneBot11Component (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Llove/forte/simbot/common/function/ConfigurerFunction;)V
+	public static synthetic fun useOneBot11Component$default (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotEvent, love/forte/simbot/event/BotEvent {
+	public abstract fun getBot ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/OneBotCommonEvent : love/forte/simbot/event/Event {
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/OneBotEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotCommonEvent {
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/RawEvent;
+	public abstract fun getSourceEventRaw ()Ljava/lang/String;
+	public fun getTime ()Llove/forte/simbot/common/time/Timestamp;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/OneBotUnknownEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotEvent {
+	public fun <init> (Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/UnknownEvent;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Llove/forte/simbot/component/onebot/v11/event/UnknownEvent;
+	public final fun copy (Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/UnknownEvent;)Llove/forte/simbot/component/onebot/v11/core/event/OneBotUnknownEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/event/OneBotUnknownEvent;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/UnknownEvent;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/event/OneBotUnknownEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public synthetic fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/RawEvent;
+	public fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/UnknownEvent;
+	public fun getSourceEventRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/OneBotUnsupportedEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotEvent {
+	public fun <init> (Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/RawEvent;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Llove/forte/simbot/component/onebot/v11/event/RawEvent;
+	public final fun copy (Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/RawEvent;)Llove/forte/simbot/component/onebot/v11/core/event/OneBotUnsupportedEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/event/OneBotUnsupportedEvent;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/RawEvent;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/event/OneBotUnsupportedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/RawEvent;
+	public fun getSourceEventRaw ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotAnonymousGroupMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupMessageEvent, love/forte/simbot/event/ChatGroupMessageEvent {
+	public abstract synthetic fun author (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getAuthor ()Llove/forte/simbot/common/id/IDContainer;
+	public fun getAuthor ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getAuthor ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getAuthor ()Llove/forte/simbot/definition/Member;
+	public fun getAuthorAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getAuthorReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotFriendMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotPrivateMessageEvent, love/forte/simbot/event/ContactMessageEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotFriend;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Contact;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotMessageEvent, love/forte/simbot/event/ChatGroupEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+	public fun getMessageId ()Llove/forte/simbot/common/id/ID;
+	public fun getRawMessage ()Ljava/lang/String;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent;
+	public fun getSubType ()Ljava/lang/String;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupPrivateMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotPrivateMessageEvent, love/forte/simbot/event/MemberMessageEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotMessageEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent, love/forte/simbot/event/MessageEvent {
+	public abstract fun getBot ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/message/RawMessageEvent;
+	public abstract synthetic fun reply (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun reply (Llove/forte/simbot/message/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun reply (Llove/forte/simbot/message/MessageContent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun replyAsync (Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public fun replyAsync (Llove/forte/simbot/message/Message;)Ljava/util/concurrent/CompletableFuture;
+	public fun replyAsync (Llove/forte/simbot/message/MessageContent;)Ljava/util/concurrent/CompletableFuture;
+	public fun replyBlocking (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun replyBlocking (Ljava/lang/String;)Llove/forte/simbot/message/MessageReceipt;
+	public fun replyBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun replyBlocking (Llove/forte/simbot/message/Message;)Llove/forte/simbot/message/MessageReceipt;
+	public fun replyBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt;
+	public synthetic fun replyBlocking (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/message/MessageReceipt;
+	public fun replyReserve (Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun replyReserve (Llove/forte/simbot/message/Message;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun replyReserve (Llove/forte/simbot/message/MessageContent;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotNormalGroupMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupMessageEvent, love/forte/simbot/event/ChatGroupMessageEvent {
+	public abstract synthetic fun author (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getAuthor ()Llove/forte/simbot/common/id/IDContainer;
+	public fun getAuthor ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getAuthor ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getAuthor ()Llove/forte/simbot/definition/Member;
+	public fun getAuthorAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getAuthorReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotNoticeGroupMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotGroupMessageEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/message/OneBotPrivateMessageEvent : love/forte/simbot/component/onebot/v11/core/event/message/OneBotMessageEvent {
+	public abstract fun getMessageContent ()Llove/forte/simbot/component/onebot/v11/message/OneBotMessageContent;
+	public fun getMessageType ()Ljava/lang/String;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent;
+	public fun getSubType ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/meta/OneBotHeartbeatEvent : love/forte/simbot/component/onebot/v11/core/event/meta/OneBotMetaEvent {
+	public fun getIntervalMilliseconds ()J
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent;
+	public fun getStatus ()Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/meta/OneBotHeartbeatEventKt {
+	public static final fun getInterval (Llove/forte/simbot/component/onebot/v11/core/event/meta/OneBotHeartbeatEvent;)J
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/meta/OneBotLifecycleEvent : love/forte/simbot/component/onebot/v11/core/event/meta/OneBotMetaEvent {
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent;
+	public fun getSubType ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/meta/OneBotMetaEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent {
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotBotSelfPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendAddEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent {
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendRecallEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/ContactEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAuthorId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotFriend;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Contact;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getMessageId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupAdminEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getSubType ()Ljava/lang/String;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun isSet ()Z
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupAdminEventKt {
+	public static final fun isNotSet (Llove/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupAdminEvent;)Z
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupBanEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getDurationSeconds ()J
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getOperatorId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getSubType ()Ljava/lang/String;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun isBan ()Z
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupBanEventKt {
+	public static final fun getDuration (Llove/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupBanEvent;)J
+	public static final fun isLeftBan (Llove/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupBanEvent;)Z
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupChangeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/MemberIncreaseOrDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getMember ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getMember ()Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupMemberDecreaseEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupChangeEvent, love/forte/simbot/event/MemberDecreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getMember ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getMember ()Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun member$suspendImpl (Llove/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupMemberDecreaseEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupMemberIncreaseEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupChangeEvent, love/forte/simbot/event/MemberIncreaseEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getMember ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getMember ()Llove/forte/simbot/definition/Member;
+	public fun getMemberAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getMemberReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupRecallEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/ChatGroupEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getAuthorId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getMessageId ()Llove/forte/simbot/common/id/ID;
+	public fun getOperatorId ()Llove/forte/simbot/common/id/LongID;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupUploadEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/ChatGroupEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/ChatRoom;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getFileInfo ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotHonorEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent {
+	public fun getHonorType ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotLuckyKingEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent {
+	public fun getTargetId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotMemberPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent {
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getHonorType ()Ljava/lang/String;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent {
+	public fun getTargetId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption : love/forte/simbot/ability/AcceptOption {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Companion;
+	public static final fun remark (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Remark;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Companion {
+	public final fun remark (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Remark;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Remark : love/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Remark;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Remark;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption$Remark;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRemark ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestEvent : love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent {
+	public abstract synthetic fun accept ([Llove/forte/simbot/ability/AcceptOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getFlag ()Ljava/lang/String;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getRequesterId ()Llove/forte/simbot/common/id/LongID;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent;
+	public fun getType ()Llove/forte/simbot/event/RequestEvent$Type;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestEvent : love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent, love/forte/simbot/event/OrganizationJoinRequestEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Organization;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public fun getFlag ()Ljava/lang/String;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getRequester ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotStranger;
+	public synthetic fun getRequester ()Llove/forte/simbot/definition/User;
+	public fun getRequesterAsync ()Ljava/util/concurrent/CompletableFuture;
+	public synthetic fun getRequesterId ()Llove/forte/simbot/common/id/ID;
+	public fun getRequesterId ()Llove/forte/simbot/common/id/LongID;
+	public fun getRequesterReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent;
+	public fun getType ()Llove/forte/simbot/event/RequestEvent$Type;
+	public abstract synthetic fun reject ([Llove/forte/simbot/ability/RejectOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun requester (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption : love/forte/simbot/ability/RejectOption {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Companion;
+	public static final fun reason (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Reason;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Companion {
+	public final fun reason (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Reason;
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Reason : love/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Reason;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Reason;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/core/event/request/OneBotGroupRequestRejectOption$Reason;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/request/OneBotRequestEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent, love/forte/simbot/event/RequestEvent {
+	public abstract synthetic fun accept (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun accept ([Llove/forte/simbot/ability/AcceptOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/request/RawRequestEvent;
+	public abstract synthetic fun reject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract synthetic fun reject ([Llove/forte/simbot/ability/RejectOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/stage/OneBotBotRegisteredEvent : love/forte/simbot/component/onebot/v11/core/event/stage/OneBotBotStageEvent, love/forte/simbot/event/BotRegisteredEvent {
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/stage/OneBotBotStageEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotCommonEvent, love/forte/simbot/event/BotStageEvent {
+	public abstract fun getBot ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/stage/OneBotBotStartedEvent : love/forte/simbot/component/onebot/v11/core/event/stage/OneBotBotStageEvent, love/forte/simbot/event/BotStartedEvent {
+}
+
+public final class love/forte/simbot/component/onebot/v11/core/message/OneBotMessageExtensions {
+	public static final synthetic fun getImageInfo (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final synthetic fun getImageInfo (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getImageInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getImageInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getImageInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getImageInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun getImageInfoAsync$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun getImageInfoAsync$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getImageInfoBlocking (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;
+	public static final fun getImageInfoBlocking (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/component/onebot/v11/core/api/GetImageResult;
+	public static final fun getImageInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getImageInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getImageInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getImageInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getImageInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getImageInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun getImageInfoReserve$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun getImageInfoReserve$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final synthetic fun getRecordInfo (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getRecordInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getRecordInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getRecordInfoAsync (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Ljava/util/concurrent/CompletableFuture;
+	public static synthetic fun getRecordInfoAsync$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Ljava/util/concurrent/CompletableFuture;
+	public static final fun getRecordInfoBlocking (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/core/api/GetRecordResult;
+	public static final fun getRecordInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getRecordInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static final fun getRecordInfoReserve (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public static synthetic fun getRecordInfoReserve$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;Ljava/lang/String;Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+}
+

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
@@ -95,6 +95,7 @@ kotlin {
 
         jvmTest.dependencies {
             implementation(libs.log4j.api)
+            implementation(libs.mockk)
             implementation(libs.log4j.core)
             implementation(libs.log4j.slf4j2)
             implementation(libs.kotlinPoet)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotFriendImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotFriendImpl.kt
@@ -24,7 +24,6 @@ import love.forte.simbot.component.onebot.v11.core.api.GetFriendListResult
 import love.forte.simbot.component.onebot.v11.core.api.GetStrangerInfoApi
 import love.forte.simbot.component.onebot.v11.core.api.SendLikeApi
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
@@ -40,41 +39,49 @@ internal abstract class OneBotFriendImpl : OneBotFriend {
     protected abstract val bot: OneBotBotImpl
 
     override suspend fun send(text: String): OneBotMessageReceipt {
-        return sendPrivateTextMsgApi(
-            target = id,
-            text = text,
-        ).requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(
+            sendPrivateTextMsgApi(
+                target = id,
+                text = text,
+            )
+        ).toReceipt(bot)
     }
 
     override suspend fun send(messageContent: MessageContent): OneBotMessageReceipt {
         if (messageContent is OneBotMessageContent) {
-            return sendPrivateMsgApi(
-                target = id,
-                message = messageContent.sourceSegments,
-            ).requestDataBy(bot).toReceipt(bot)
+            return bot.executeData(
+                sendPrivateMsgApi(
+                    target = id,
+                    message = messageContent.sourceSegments,
+                )
+            ).toReceipt(bot)
         }
 
         return send(messageContent.messages)
     }
 
     override suspend fun send(message: Message): OneBotMessageReceipt {
-        return sendPrivateMsgApi(
-            target = id,
-            message = message.resolveToOneBotSegmentList(bot)
-        ).requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(
+            sendPrivateMsgApi(
+                target = id,
+                message = message.resolveToOneBotSegmentList(bot)
+            )
+        ).toReceipt(bot)
     }
 
     override suspend fun sendLike(times: Int) {
-        SendLikeApi.create(
-            userId = id,
-            times = times
-        ).requestDataBy(bot)
+        bot.executeData(
+            SendLikeApi.create(
+                userId = id,
+                times = times
+            )
+        )
     }
 
     override suspend fun toStranger(): OneBotStranger =
-        GetStrangerInfoApi.create(userId = id)
-            .requestDataBy(bot)
-            .toStranger(bot)
+        bot.executeData(
+            GetStrangerInfoApi.create(userId = id)
+        ).toStranger(bot)
 
     override fun toString(): String = "OneBotFriend(id=$id, bot=${bot.id})"
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotMemberImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/actor/internal/OneBotMemberImpl.kt
@@ -27,7 +27,6 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotMemberRole
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotStranger
 import love.forte.simbot.component.onebot.v11.core.api.*
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.internal.message.toReceipt
 import love.forte.simbot.component.onebot.v11.core.utils.resolveToOneBotSegmentList
 import love.forte.simbot.component.onebot.v11.core.utils.sendPrivateMsgApi
@@ -62,28 +61,34 @@ internal abstract class OneBotMemberImpl(
     override var nick: String? = initialNick
 
     override suspend fun send(text: String): OneBotMessageReceipt {
-        return sendPrivateTextMsgApi(
-            target = id,
-            text = text,
-        ).requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(
+            sendPrivateTextMsgApi(
+                target = id,
+                text = text,
+            )
+        ).toReceipt(bot)
     }
 
     override suspend fun send(messageContent: MessageContent): OneBotMessageReceipt {
         if (messageContent is OneBotMessageContent) {
-            return sendPrivateMsgApi(
-                target = id,
-                message = messageContent.sourceSegments,
-            ).requestDataBy(bot).toReceipt(bot)
+            return bot.executeData(
+                sendPrivateMsgApi(
+                    target = id,
+                    message = messageContent.sourceSegments,
+                )
+            ).toReceipt(bot)
         }
 
         return send(messageContent.messages)
     }
 
     override suspend fun send(message: Message): OneBotMessageReceipt {
-        return sendPrivateMsgApi(
-            target = id,
-            message = message.resolveToOneBotSegmentList(bot)
-        ).requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(
+            sendPrivateMsgApi(
+                target = id,
+                message = message.resolveToOneBotSegmentList(bot)
+            )
+        ).toReceipt(bot)
     }
 
     override suspend fun delete(vararg options: DeleteOption) {
@@ -108,11 +113,13 @@ internal abstract class OneBotMemberImpl(
             }
 
         kotlin.runCatching {
-            SetGroupKickApi.create(
-                groupId = groupId,
-                userId = id,
-                rejectAddRequest = mark.isRejectRequest
-            ).requestDataBy(bot)
+            bot.executeData(
+                SetGroupKickApi.create(
+                    groupId = groupId,
+                    userId = id,
+                    rejectAddRequest = mark.isRejectRequest
+                )
+            )
         }.onFailure { err ->
             if (!mark.isIgnoreFailure) {
                 throw err
@@ -169,18 +176,22 @@ internal abstract class OneBotMemberImpl(
     protected open suspend fun doBan(seconds: Long) {
         val groupId = groupIdOrFailure
 
-        SetGroupBanApi.create(
-            groupId = groupId,
-            userId = id,
-            duration = seconds
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetGroupBanApi.create(
+                groupId = groupId,
+                userId = id,
+                duration = seconds
+            )
+        )
     }
 
     override suspend fun getSourceMemberInfo(): GetGroupMemberInfoResult {
-        return GetGroupMemberInfoApi.create(
-            groupId = groupIdOrFailure,
-            userId = id,
-        ).requestDataBy(bot)
+        return bot.executeData(
+            GetGroupMemberInfoApi.create(
+                groupId = groupIdOrFailure,
+                userId = id,
+            )
+        )
     }
 
     override suspend fun setSpecialTitle(specialTitle: String?) {
@@ -206,30 +217,36 @@ internal abstract class OneBotMemberImpl(
     }
 
     private suspend fun setSpecialTitle0(specialTitle: String?, duration: Long?) {
-        SetGroupSpecialTitleApi.create(
-            groupId = groupIdOrFailure,
-            userId = id,
-            specialTitle = specialTitle,
-            duration = duration
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetGroupSpecialTitleApi.create(
+                groupId = groupIdOrFailure,
+                userId = id,
+                specialTitle = specialTitle,
+                duration = duration
+            )
+        )
     }
 
     override suspend fun setNick(newNick: String?) {
-        SetGroupCardApi.create(
-            groupId = groupIdOrFailure,
-            userId = id,
-            card = newNick
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetGroupCardApi.create(
+                groupId = groupIdOrFailure,
+                userId = id,
+                card = newNick
+            )
+        )
 
         this.nick = newNick
     }
 
     override suspend fun setAdmin(enable: Boolean) {
-        SetGroupAdminApi.create(
-            groupId = groupIdOrFailure,
-            userId = id,
-            enable = enable
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetGroupAdminApi.create(
+                groupId = groupIdOrFailure,
+                userId = id,
+                enable = enable
+            )
+        )
 
         this.role = if (enable) {
             OneBotMemberRole.ADMIN
@@ -239,8 +256,9 @@ internal abstract class OneBotMemberImpl(
     }
 
     override suspend fun toStranger(): OneBotStranger =
-        GetStrangerInfoApi.create(userId = id)
-            .requestDataBy(bot)
+        bot.executeData(
+            GetStrangerInfoApi.create(userId = id)
+        )
             .toStranger(bot)
 
     override fun toString(): String = "OneBotMember(id=$id, bot=${bot.id})"
@@ -290,11 +308,13 @@ internal class OneBotMemberGroupMessageEventSenderImpl(
         } else {
             val groupId = groupIdOrFailure
 
-            SetGroupAnonymousBanApi.create(
-                groupId = groupId,
-                anonymousFlag = anonymous.flag,
-                duration = seconds
-            ).requestDataBy(bot)
+            bot.executeData(
+                SetGroupAnonymousBanApi.create(
+                    groupId = groupId,
+                    anonymousFlag = anonymous.flag,
+                    duration = seconds
+                )
+            )
         }
     }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApiExecutable.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2024. ForteScarlet.
+ *
+ * This file is part of simbot-component-onebot.
+ *
+ * simbot-component-onebot is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-onebot is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-onebot.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.onebot.v11.core.api
+
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import love.forte.simbot.suspendrunner.ST
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.jvm.JvmInline
+
+
+/**
+ * 可以用于执行 [OneBotApi] 的执行器接口描述。
+ *
+ * @since 1.1.0
+ *
+ * @author ForteScarlet
+ */
+public interface OneBotApiExecutable {
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [api] 并得到原始的 [HttpResponse] 结果。
+     *
+     * 更多描述参考 [OneBotApi.request]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @see OneBotApi.request
+     */
+    @ST
+    public suspend fun execute(api: OneBotApi<*>): HttpResponse
+
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [api] 并得到原始的 [String] 结果。
+     *
+     * 更多描述参考 [OneBotApi.requestRaw]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @see OneBotApi.requestRaw
+     */
+    @ST
+    public suspend fun executeRaw(api: OneBotApi<*>): String
+
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [api] 并得到 [OneBotApiResult] 结果。
+     *
+     * 更多描述参考 [OneBotApi.requestResult]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @see OneBotApi.requestResult
+     */
+    @ST
+    public suspend fun <T : Any> executeResult(api: OneBotApi<T>): OneBotApiResult<T>
+
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [api] 并得到 [T] 结果。
+     *
+     * 更多描述参考 [OneBotApi.requestData]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @throws IllegalStateException 如果响应结果体的状态 [OneBotApiResult.retcode]
+     * 不是成功或 [OneBotApiResult.data] 为 `null`
+     * @see OneBotApi.requestData
+     */
+    @ST
+    public suspend fun <T : Any> executeData(api: OneBotApi<T>): T
+}
+
+/**
+ * 在 [OneBotApiExecutable] 的基础上提供更多作用域API。
+ *
+ * @since 1.1.0
+ *
+ * @see OneBotApiExecutable
+ */
+@JvmInline
+public value class OneBotApiExecutableScope(private val executable: OneBotApiExecutable) {
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [OneBotApi] 并得到原始的 [HttpResponse] 结果。
+     *
+     * 更多描述参考 [OneBotApi.request]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @see OneBotApi.request
+     */
+    public suspend fun OneBotApi<*>.execute(): HttpResponse =
+        executable.execute(this)
+
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [OneBotApi] 并得到原始的 [String] 结果。
+     *
+     * 更多描述参考 [OneBotApi.requestRaw]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @see OneBotApi.requestRaw
+     */
+    public suspend fun OneBotApi<*>.executeRaw(): String =
+        executable.executeRaw(this)
+
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [OneBotApi] 并得到 [OneBotApiResult] 结果。
+     *
+     * 更多描述参考 [OneBotApi.requestResult]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @see OneBotApi.requestResult
+     */
+    public suspend fun <T : Any> OneBotApi<T>.executeResult(): OneBotApiResult<T> =
+        executable.executeResult(this)
+
+    /**
+     * 使用当前 [OneBotApiExecutable] 执行 [OneBotApi] 并得到 [T] 结果。
+     *
+     * 更多描述参考 [OneBotApi.requestData]
+     *
+     * @since 1.1.0
+     *
+     * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
+     * @throws IllegalStateException 如果响应结果体的状态 [OneBotApiResult.retcode]
+     * 不是成功或 [OneBotApiResult.data] 为 `null`
+     * @see OneBotApi.requestData
+     */
+    public suspend fun <T : Any> OneBotApi<T>.executeData(): T =
+        executable.executeData(this)
+}
+
+/**
+ * 在 [OneBotApiExecutableScope] 的作用域下执行 [action]。
+ *
+ * ```kotlin
+ * withExecutableScope(executable) {
+ *     api.execute()
+ * }
+ * ```
+ *
+ * @since 1.1.0
+ */
+@OptIn(ExperimentalContracts::class)
+public inline fun <T> withExecutableScope(
+    executable: OneBotApiExecutable,
+    action: OneBotApiExecutableScope.() -> T
+): T {
+    contract {
+        callsInPlace(action, InvocationKind.EXACTLY_ONCE)
+    }
+    return OneBotApiExecutableScope(executable).action()
+}
+
+/**
+ * 在 [OneBotApiExecutableScope] 的作用域下执行 [action]。
+ *
+ * ```kotlin
+ * executable.inExecutableScope {
+ *     api.execute()
+ * }
+ * ```
+ *
+ * @since 1.1.0
+ */
+@OptIn(ExperimentalContracts::class)
+public inline fun <T> OneBotApiExecutable.inExecutableScope(
+    action: OneBotApiExecutableScope.() -> T
+): T {
+    contract {
+        callsInPlace(action, InvocationKind.EXACTLY_ONCE)
+    }
+    return withExecutableScope(this, action)
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBot.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBot.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.component.onebot.v11.core.bot
 
 import io.ktor.client.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -66,7 +67,7 @@ import kotlin.jvm.JvmSynthetic
  * @author ForteScarlet
  */
 @OneBotInternalImplementationsOnly
-public interface OneBotBot : Bot {
+public interface OneBotBot : Bot, OneBotApiExecutable {
     override val coroutineContext: CoroutineContext
 
     /**
@@ -97,15 +98,15 @@ public interface OneBotBot : Bot {
     public val apiHost: Url
 
     /**
-     * [OneBotBotConfiguration] 中配置的 accessToken。
-     *
-     * 分开使用 [apiAccessToken] 或 [eventAccessToken]，
-     * [accessToken] 将会在 v1.0.0 版本后移除。
+     * @suppress 分开使用 [apiAccessToken] 或 [eventAccessToken]。
      */
-    @Deprecated("Use `apiAccessToken` or `eventAccessToken`", ReplaceWith("apiAccessToken"))
+    @Deprecated(
+        "Use `apiAccessToken` or `eventAccessToken`",
+        ReplaceWith("apiAccessToken"),
+        level = DeprecationLevel.HIDDEN
+    )
     public val accessToken: String?
         get() = apiAccessToken
-    // TODO Removal
 
     /**
      * [OneBotBotConfiguration] 中配置的 [apiAccessToken][OneBotBotConfiguration.apiAccessToken]。
@@ -247,6 +248,7 @@ public interface OneBotBot : Bot {
     @ExperimentalOneBotAPI
     public suspend fun getMessageContent(messageId: ID): OneBotMessageContent
 
+
 }
 
 /**
@@ -348,3 +350,5 @@ public interface OneBotBotGroupRelation : GroupRelation {
     public suspend fun member(groupId: ID, memberId: ID): OneBotMember?
 
 }
+
+

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotRequests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotRequests.kt
@@ -35,14 +35,14 @@ import kotlin.jvm.JvmSynthetic
  *
  * @see OneBotApi.request
  */
+@Deprecated(
+    "Use OneBotBot.execute",
+    ReplaceWith("bot.execute(this)")
+)
 @JvmSynthetic
 public suspend fun OneBotApi<*>.requestBy(
     bot: OneBotBot,
-): HttpResponse = request(
-    client = bot.apiClient,
-    host = bot.apiHost,
-    accessToken = bot.apiAccessToken
-)
+): HttpResponse = bot.execute(this)
 
 /**
  * 使用 [bot] 对 [this] 发起一次请求，
@@ -53,14 +53,14 @@ public suspend fun OneBotApi<*>.requestBy(
  * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
  * @see OneBotApi.requestRaw
  */
+@Deprecated(
+    "Use OneBotBot.executeRaw",
+    ReplaceWith("bot.executeRaw(this)")
+)
 @JvmSynthetic
 public suspend fun OneBotApi<*>.requestRawBy(
     bot: OneBotBot,
-): String = requestRaw(
-    client = bot.apiClient,
-    host = bot.apiHost,
-    accessToken = bot.apiAccessToken
-)
+): String = bot.executeRaw(this)
 
 /**
  * 使用 [bot] 对 [this] 发起一次请求，
@@ -71,15 +71,14 @@ public suspend fun OneBotApi<*>.requestRawBy(
  * @throws OneBotApiResponseNotSuccessException 如果响应状态码不是 2xx (参考 [HttpStatusCode.isSuccess])
  * @see OneBotApi.requestResult
  */
+@Deprecated(
+    "Use OneBotBot.executeResult",
+    ReplaceWith("bot.executeResult(this)")
+)
 @JvmSynthetic
 public suspend fun <T : Any> OneBotApi<T>.requestResultBy(
     bot: OneBotBot,
-): OneBotApiResult<T> = requestResult(
-    client = bot.apiClient,
-    host = bot.apiHost,
-    accessToken = bot.apiAccessToken,
-    decoder = bot.decoderJson
-)
+): OneBotApiResult<T> = bot.executeResult(this)
 
 /**
  * 使用 [bot] 对 [this] 发起一次请求，
@@ -91,14 +90,13 @@ public suspend fun <T : Any> OneBotApi<T>.requestResultBy(
  * @throws IllegalStateException 如果响应结果体的状态 [OneBotApiResult.retcode]
  * 不是成功或 [OneBotApiResult.data] 为 `null`
  *
- * @see OneBotApi.requestData
+ * @see OneBotBot.executeData
  */
+@Deprecated(
+    "Use OneBotBot.executeData",
+    ReplaceWith("bot.executeData(this)")
+)
 @JvmSynthetic
 public suspend fun <T : Any> OneBotApi<T>.requestDataBy(
     bot: OneBotBot,
-): T = requestData(
-    client = bot.apiClient,
-    host = bot.apiHost,
-    accessToken = bot.apiAccessToken,
-    decoder = bot.decoderJson
-)
+): T = bot.executeData(this)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotGroupMessageEventImpl.kt
@@ -23,7 +23,6 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
 import love.forte.simbot.component.onebot.v11.core.actor.internal.toMember
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.message.OneBotAnonymousGroupMessageEvent
 import love.forte.simbot.component.onebot.v11.core.event.message.OneBotGroupMessageEvent
@@ -69,27 +68,31 @@ internal abstract class OneBotGroupMessageEventImpl(
             reply = sourceEvent.messageId
         )
 
-        return api.requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(api).toReceipt(bot)
     }
 
     override suspend fun reply(messageContent: MessageContent): OneBotMessageReceipt {
         if (messageContent is OneBotMessageContent) {
-            return sendGroupMsgApi(
-                target = sourceEvent.groupId,
-                message = sourceEvent.message,
-                reply = sourceEvent.messageId
-            ).requestDataBy(bot).toReceipt(bot)
+            return bot.executeData(
+                sendGroupMsgApi(
+                    target = sourceEvent.groupId,
+                    message = sourceEvent.message,
+                    reply = sourceEvent.messageId
+                )
+            ).toReceipt(bot)
         }
 
         return reply(messageContent.messages)
     }
 
     override suspend fun reply(message: Message): OneBotMessageReceipt {
-        return sendGroupMsgApi(
-            target = sourceEvent.groupId,
-            message = message.resolveToOneBotSegmentList(bot),
-            reply = sourceEvent.messageId
-        ).requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(
+            sendGroupMsgApi(
+                target = sourceEvent.groupId,
+                message = message.resolveToOneBotSegmentList(bot),
+                reply = sourceEvent.messageId
+            )
+        ).toReceipt(bot)
     }
 }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/message/OneBotPrivateMessageEventImpl.kt
@@ -25,7 +25,6 @@ import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
 import love.forte.simbot.component.onebot.v11.core.actor.internal.toFriend
 import love.forte.simbot.component.onebot.v11.core.actor.internal.toMember
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.message.OneBotFriendMessageEvent
 import love.forte.simbot.component.onebot.v11.core.event.message.OneBotGroupPrivateMessageEvent
@@ -64,25 +63,29 @@ internal abstract class OneBotPrivateMessageEventImpl(
             text,
         )
 
-        return api.requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(api).toReceipt(bot)
     }
 
     override suspend fun reply(messageContent: MessageContent): OneBotMessageReceipt {
         if (messageContent is OneBotMessageContent) {
-            return sendPrivateMsgApi(
-                target = sourceEvent.userId,
-                message = sourceEvent.message,
-            ).requestDataBy(bot).toReceipt(bot)
+            return bot.executeData(
+                sendPrivateMsgApi(
+                    target = sourceEvent.userId,
+                    message = sourceEvent.message,
+                )
+            ).toReceipt(bot)
         }
 
         return reply(messageContent.messages)
     }
 
     override suspend fun reply(message: Message): OneBotMessageReceipt {
-        return sendPrivateMsgApi(
-            target = sourceEvent.userId,
-            message = message.resolveToOneBotSegmentList(bot)
-        ).requestDataBy(bot).toReceipt(bot)
+        return bot.executeData(
+            sendPrivateMsgApi(
+                target = sourceEvent.userId,
+                message = message.resolveToOneBotSegmentList(bot)
+            )
+        ).toReceipt(bot)
     }
 }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/request/OneBotRequestEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/request/OneBotRequestEventImpl.kt
@@ -29,7 +29,6 @@ import love.forte.simbot.component.onebot.v11.core.api.SetFriendAddRequestApi
 import love.forte.simbot.component.onebot.v11.core.api.SetGroupAddRequestApi
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.core.event.internal.eventToString
 import love.forte.simbot.component.onebot.v11.core.event.request.*
 import love.forte.simbot.component.onebot.v11.event.request.RawFriendRequestEvent
@@ -70,18 +69,22 @@ internal class OneBotFriendRequestEventImpl(
                 as? OneBotFriendRequestAcceptOption.Remark
             )?.remark
 
-        SetFriendAddRequestApi.create(
-            flag = sourceEvent.flag,
-            approve = true,
-            remark = remark
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetFriendAddRequestApi.create(
+                flag = sourceEvent.flag,
+                approve = true,
+                remark = remark
+            )
+        )
     }
 
     override suspend fun doReject(options: Array<out RejectOption>) {
-        SetFriendAddRequestApi.create(
-            flag = sourceEvent.flag,
-            approve = false,
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetFriendAddRequestApi.create(
+                flag = sourceEvent.flag,
+                approve = false,
+            )
+        )
     }
 
     override fun toString(): String =
@@ -94,11 +97,13 @@ internal class OneBotGroupRequestEventImpl(
     override val bot: OneBotBotImpl,
 ) : OneBotRequestEventImpl(), OneBotGroupRequestEvent {
     override suspend fun doAccept(options: Array<out AcceptOption>) {
-        SetGroupAddRequestApi.create(
-            flag = sourceEvent.flag,
-            subType = sourceEvent.subType,
-            approve = true
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetGroupAddRequestApi.create(
+                flag = sourceEvent.flag,
+                subType = sourceEvent.subType,
+                approve = true
+            )
+        )
     }
 
     override suspend fun doReject(options: Array<out RejectOption>) {
@@ -107,12 +112,14 @@ internal class OneBotGroupRequestEventImpl(
                 as? OneBotGroupRequestRejectOption.Reason
             )?.reason
 
-        SetGroupAddRequestApi.create(
-            flag = sourceEvent.flag,
-            subType = sourceEvent.subType,
-            approve = false,
-            reason = reason
-        ).requestDataBy(bot)
+        bot.executeData(
+            SetGroupAddRequestApi.create(
+                flag = sourceEvent.flag,
+                subType = sourceEvent.subType,
+                approve = false,
+                reason = reason
+            )
+        )
     }
 
     override suspend fun content(): OneBotGroup {
@@ -121,9 +128,10 @@ internal class OneBotGroupRequestEventImpl(
     }
 
     override suspend fun requester(): OneBotStranger {
-        return GetStrangerInfoApi
-            .create(sourceEvent.userId)
-            .requestDataBy(bot)
+        return bot.executeData(
+            GetStrangerInfoApi
+                .create(sourceEvent.userId)
+        )
             .toStranger(bot)
     }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/internal/message/OneBotMessageContentImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/internal/message/OneBotMessageContentImpl.kt
@@ -22,7 +22,6 @@ import love.forte.simbot.ability.StandardDeleteOption
 import love.forte.simbot.common.id.ID
 import love.forte.simbot.component.onebot.v11.core.api.DeleteMsgApi
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.component.onebot.v11.message.resolveToMessageElement
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotMessageSegment
@@ -59,7 +58,7 @@ internal class OneBotMessageContentImpl(
 
     override suspend fun delete(vararg options: DeleteOption) {
         runCatching {
-            DeleteMsgApi.create(id).requestDataBy(bot)
+            bot.executeData(DeleteMsgApi.create(id))
         }.onFailure { ex ->
             if (StandardDeleteOption.IGNORE_ON_FAILURE !in options) {
                 throw ex

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/internal/message/OneBotMessageReceiptImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/internal/message/OneBotMessageReceiptImpl.kt
@@ -23,7 +23,6 @@ import love.forte.simbot.common.id.ID
 import love.forte.simbot.component.onebot.v11.core.api.DeleteMsgApi
 import love.forte.simbot.component.onebot.v11.core.api.SendMsgResult
 import love.forte.simbot.component.onebot.v11.core.bot.internal.OneBotBotImpl
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.message.OneBotMessageReceipt
 
 
@@ -36,7 +35,7 @@ internal class OneBotMessageReceiptImpl(
 ) : OneBotMessageReceipt {
     override suspend fun delete(vararg options: DeleteOption) {
         kotlin.runCatching {
-            DeleteMsgApi.create(messageId).requestDataBy(bot)
+            bot.executeData(DeleteMsgApi.create(messageId))
         }.onFailure { ex ->
             if (StandardDeleteOption.IGNORE_ON_FAILURE !in options) {
                 throw ex

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/message/OneBotMessageExtensions.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/message/OneBotMessageExtensions.kt
@@ -28,7 +28,6 @@ import love.forte.simbot.common.collectable.asCollectable
 import love.forte.simbot.component.onebot.common.annotations.ExperimentalOneBotAPI
 import love.forte.simbot.component.onebot.v11.core.api.*
 import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
-import love.forte.simbot.component.onebot.v11.core.bot.requestDataBy
 import love.forte.simbot.component.onebot.v11.message.segment.*
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
@@ -42,7 +41,7 @@ import kotlin.jvm.JvmSynthetic
  */
 @JvmSynthetic
 public suspend fun OneBotImage.getImageInfo(bot: OneBotBot): GetImageResult =
-    GetImageApi.create(data.file).requestDataBy(bot)
+    bot.executeData(GetImageApi.create(data.file))
 
 /**
  * 通过 [bot] 使用 [GetImageApi] 查询 [OneBotImage.Element.segment]
@@ -64,7 +63,7 @@ public suspend fun OneBotImage.Element.getImageInfo(bot: OneBotBot): GetImageRes
  */
 @JvmSynthetic
 public suspend fun OneBotRecord.getRecordInfo(bot: OneBotBot, outFormat: String): GetRecordResult =
-    GetRecordApi.create(data.file, outFormat).requestDataBy(bot)
+    bot.executeData(GetRecordApi.create(data.file, outFormat))
 
 /**
  * 通过 [bot] 使用 [GetForwardMsgApi] 查询 [OneBotForward] 内的消息节点列表。
@@ -74,7 +73,7 @@ public suspend fun OneBotRecord.getRecordInfo(bot: OneBotBot, outFormat: String)
 @JvmSynthetic
 @ExperimentalOneBotAPI
 public suspend fun OneBotForward.getForwardNodes(bot: OneBotBot): List<OneBotForwardNode> {
-    return GetForwardMsgApi.create(id).requestDataBy(bot).message
+    return bot.executeData(GetForwardMsgApi.create(id)).message
 }
 
 /**

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotRequests.jvm.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotRequests.jvm.kt
@@ -20,9 +20,8 @@
 
 package love.forte.simbot.component.onebot.v11.core.bot
 
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.isSuccess
+import io.ktor.client.statement.*
+import io.ktor.http.*
 import love.forte.simbot.annotations.Api4J
 import love.forte.simbot.component.onebot.v11.core.api.OneBotApi
 import love.forte.simbot.component.onebot.v11.core.api.OneBotApiResponseNotSuccessException
@@ -45,9 +44,13 @@ import kotlin.coroutines.EmptyCoroutineContext
  *  @see requestBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeBlocking(this)")
+)
 public fun OneBotApi<*>.requestByBlocking(
     bot: OneBotBot,
-): HttpResponse = runInNoScopeBlocking { requestBy(bot) }
+): HttpResponse = runInNoScopeBlocking { bot.execute(this) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次阻塞地请求，
@@ -58,9 +61,13 @@ public fun OneBotApi<*>.requestByBlocking(
  * @see requestRawBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeRawBlocking(this)")
+)
 public fun OneBotApi<*>.requestRawByBlocking(
     bot: OneBotBot,
-): String = runInNoScopeBlocking { requestRawBy(bot) }
+): String = runInNoScopeBlocking { bot.executeRaw(this) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次阻塞地请求，
@@ -73,9 +80,13 @@ public fun OneBotApi<*>.requestRawByBlocking(
  * @see requestResultBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeResultBlocking(this)")
+)
 public fun <T : Any> OneBotApi<T>.requestResultByBlocking(
     bot: OneBotBot,
-): OneBotApiResult<T> = runInNoScopeBlocking { requestResultBy(bot) }
+): OneBotApiResult<T> = runInNoScopeBlocking { bot.executeResult(this) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次阻塞地请求，
@@ -89,9 +100,13 @@ public fun <T : Any> OneBotApi<T>.requestResultByBlocking(
  * @see requestDataBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeDataBlocking(this)")
+)
 public fun <T : Any> OneBotApi<T>.requestDataByBlocking(
     bot: OneBotBot,
-): T = runInNoScopeBlocking { requestDataBy(bot) }
+): T = runInNoScopeBlocking { bot.executeData(this) }
 //endregion
 
 //region async
@@ -104,9 +119,13 @@ public fun <T : Any> OneBotApi<T>.requestDataByBlocking(
  *  @see requestBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeAsync(this)")
+)
 public fun OneBotApi<*>.requestByAsync(
     bot: OneBotBot,
-): CompletableFuture<out HttpResponse> = runInAsync(bot) { requestBy(bot) }
+): CompletableFuture<out HttpResponse> = runInAsync(bot) { bot.execute(this@requestByAsync) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次异步地请求，
@@ -117,9 +136,13 @@ public fun OneBotApi<*>.requestByAsync(
  * @see requestRawBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeRawAsync(this)")
+)
 public fun OneBotApi<*>.requestRawByAsync(
     bot: OneBotBot,
-): CompletableFuture<out String> = runInAsync(bot) { requestRawBy(bot) }
+): CompletableFuture<out String> = runInAsync(bot) { bot.executeRaw(this@requestRawByAsync) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次异步地请求，
@@ -132,9 +155,13 @@ public fun OneBotApi<*>.requestRawByAsync(
  * @see requestResultBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeResultAsync(this)")
+)
 public fun <T : Any> OneBotApi<T>.requestResultByAsync(
     bot: OneBotBot,
-): CompletableFuture<out OneBotApiResult<T>> = runInAsync(bot) { requestResultBy(bot) }
+): CompletableFuture<out OneBotApiResult<T>> = runInAsync(bot) { bot.executeResult(this@requestResultByAsync) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次异步地请求，
@@ -148,9 +175,13 @@ public fun <T : Any> OneBotApi<T>.requestResultByAsync(
  * @see requestDataBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeDataAsync(this)")
+)
 public fun <T : Any> OneBotApi<T>.requestDataByAsync(
     bot: OneBotBot,
-): CompletableFuture<out T> = runInAsync(bot) { requestDataBy(bot) }
+): CompletableFuture<out T> = runInAsync(bot) { bot.executeData(this@requestDataByAsync) }
 //endregion
 
 //region reserve
@@ -163,9 +194,13 @@ public fun <T : Any> OneBotApi<T>.requestDataByAsync(
  *  @see requestBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeReserve(this)")
+)
 public fun OneBotApi<*>.requestByReserve(
     bot: OneBotBot,
-): SuspendReserve<HttpResponse> = suspendReserve(bot, EmptyCoroutineContext) { requestBy(bot) }
+): SuspendReserve<HttpResponse> = suspendReserve(bot, EmptyCoroutineContext) { bot.execute(this) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次预处理地请求，
@@ -176,9 +211,13 @@ public fun OneBotApi<*>.requestByReserve(
  * @see requestRawBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeRawReserve(this)")
+)
 public fun OneBotApi<*>.requestRawByReserve(
     bot: OneBotBot,
-): SuspendReserve<String> = suspendReserve(bot, EmptyCoroutineContext) { requestRawBy(bot) }
+): SuspendReserve<String> = suspendReserve(bot, EmptyCoroutineContext) { bot.executeRaw(this) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次预处理地请求，
@@ -191,9 +230,13 @@ public fun OneBotApi<*>.requestRawByReserve(
  * @see requestResultBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeResultReserve(this)")
+)
 public fun <T : Any> OneBotApi<T>.requestResultByReserve(
     bot: OneBotBot,
-): SuspendReserve<OneBotApiResult<T>> = suspendReserve(bot, EmptyCoroutineContext) { requestResultBy(bot) }
+): SuspendReserve<OneBotApiResult<T>> = suspendReserve(bot, EmptyCoroutineContext) { bot.executeResult(this) }
 
 /**
  * 使用 [bot] 对 [this] 发起一次预处理地请求，
@@ -207,7 +250,11 @@ public fun <T : Any> OneBotApi<T>.requestResultByReserve(
  * @see requestDataBy
  */
 @Api4J
+@Deprecated(
+    "Use OneBotBot.execute* API",
+    ReplaceWith("bot.executeDataReserve(this)")
+)
 public fun <T : Any> OneBotApi<T>.requestDataByReserve(
     bot: OneBotBot,
-): SuspendReserve<T> = suspendReserve(bot, EmptyCoroutineContext) { requestDataBy(bot) }
+): SuspendReserve<T> = suspendReserve(bot, EmptyCoroutineContext) { bot.executeData(this) }
 //endregion

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmTest/kotlin/ApiExecutableTests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/jvmTest/kotlin/ApiExecutableTests.kt
@@ -1,0 +1,28 @@
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import love.forte.simbot.component.onebot.v11.core.api.OneBotApi
+import love.forte.simbot.component.onebot.v11.core.api.OneBotApiExecutable
+import love.forte.simbot.component.onebot.v11.core.api.inExecutableScope
+import kotlin.test.Test
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class ApiExecutableTests {
+    // see https://github.com/mockk/mockk/issues/1282
+
+    // @Test
+    fun executableScopeTest() = runTest {
+        val executable = mockk<OneBotApiExecutable>(relaxed = true)
+        val api = mockk<OneBotApi<*>>(relaxed = true)
+
+        executable.inExecutableScope {
+            api.execute()
+        }
+
+        coVerify { executable.execute(any()) }
+    }
+
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/api/simbot-component-onebot-v11-event.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/api/simbot-component-onebot-v11-event.api
@@ -1,0 +1,842 @@
+public abstract interface class love/forte/simbot/component/onebot/v11/event/RawEvent {
+	public abstract fun getPostType ()Ljava/lang/String;
+	public abstract fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public abstract fun getTime ()J
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/UnknownEvent : love/forte/simbot/component/onebot/v11/event/RawEvent {
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPostType ()Ljava/lang/String;
+	public final fun getRaw ()Ljava/lang/String;
+	public final fun getRawJson ()Lkotlinx/serialization/json/JsonObject;
+	public final fun getReason ()Ljava/lang/Throwable;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent : love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Companion;
+	public static final field SUB_TYPE_ANONYMOUS Ljava/lang/String;
+	public static final field SUB_TYPE_NORMAL Ljava/lang/String;
+	public static final field SUB_TYPE_NOTICE Ljava/lang/String;
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Llove/forte/simbot/common/id/ID;
+	public final fun component5 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;Ljava/util/List;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/Integer;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;Ljava/util/List;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/Integer;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnonymous ()Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;
+	public fun getFont ()Ljava/lang/Integer;
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getMessage ()Ljava/util/List;
+	public fun getMessageId ()Llove/forte/simbot/common/id/ID;
+	public fun getMessageType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getRawMessage ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getSender ()Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;
+	public synthetic fun getSender ()Llove/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Sender;
+	public fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFlag ()Ljava/lang/String;
+	public final fun getId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Anonymous$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender : love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Sender {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAge ()I
+	public final fun getArea ()Ljava/lang/String;
+	public final fun getCard ()Ljava/lang/String;
+	public final fun getLevel ()Ljava/lang/String;
+	public fun getNickname ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public fun getSex ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawGroupMessageEvent$Sender$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent : love/forte/simbot/component/onebot/v11/event/RawEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Companion;
+	public static final field POST_TYPE Ljava/lang/String;
+	public abstract fun getFont ()Ljava/lang/Integer;
+	public abstract fun getMessage ()Ljava/util/List;
+	public abstract fun getMessageId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getMessageType ()Ljava/lang/String;
+	public abstract fun getRawMessage ()Ljava/lang/String;
+	public abstract fun getSender ()Llove/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Sender;
+	public abstract fun getSubType ()Ljava/lang/String;
+	public abstract fun getUserId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Companion {
+	public static final field POST_TYPE Ljava/lang/String;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Sender {
+	public abstract fun getAge ()I
+	public abstract fun getNickname ()Ljava/lang/String;
+	public abstract fun getSex ()Ljava/lang/String;
+	public abstract fun getUserId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent : love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Companion;
+	public static final field SUB_TYPE_FRIEND Ljava/lang/String;
+	public static final field SUB_TYPE_GROUP Ljava/lang/String;
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Llove/forte/simbot/common/id/ID;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/Integer;Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;)Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/Integer;Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFont ()Ljava/lang/Integer;
+	public fun getMessage ()Ljava/util/List;
+	public fun getMessageId ()Llove/forte/simbot/common/id/ID;
+	public fun getMessageType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getRawMessage ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun getSender ()Llove/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Sender;
+	public fun getSender ()Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;
+	public fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender : love/forte/simbot/component/onebot/v11/event/message/RawMessageEvent$Sender {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender$Companion;
+	public final fun component1 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;I)Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getAge ()I
+	public fun getNickname ()Ljava/lang/String;
+	public fun getSex ()Ljava/lang/String;
+	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/message/RawPrivateMessageEvent$Sender$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent : love/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent$Companion;
+	public fun <init> (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;J)V
+	public synthetic fun <init> (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;
+	public final fun component6 ()J
+	public final fun copy (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;J)Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent;JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;JILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInterval ()J
+	public fun getMetaEventType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getStatus ()Llove/forte/simbot/component/onebot/v11/common/api/StatusResult;
+	public fun getTime ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/meta/RawHeartbeatEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent : love/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMetaEventType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/meta/RawLifecycleEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent : love/forte/simbot/component/onebot/v11/event/RawEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent$Companion;
+	public static final field POST_TYPE Ljava/lang/String;
+	public abstract fun getMetaEventType ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent$Companion {
+	public static final field POST_TYPE Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getNoticeType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawFriendAddEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawFriendRecallEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent$Companion;
+	public static final field SUB_TYPE_SET Ljava/lang/String;
+	public static final field SUB_TYPE_UNSET Ljava/lang/String;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupAdminEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent$Companion;
+	public static final field SUB_TYPE_BAN Ljava/lang/String;
+	public static final field SUB_TYPE_LIFT_BAN Ljava/lang/String;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;J)V
+	public synthetic fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component8 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component9 ()J
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;J)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;JILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()J
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public final fun getOperatorId ()Llove/forte/simbot/common/id/LongID;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupBanEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)V
+	public synthetic fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component8 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public final fun getOperatorId ()Llove/forte/simbot/common/id/LongID;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupDecreaseEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)V
+	public synthetic fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component8 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public final fun getOperatorId ()Llove/forte/simbot/common/id/LongID;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupIncreaseEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component8 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getMessageId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public final fun getOperatorId ()Llove/forte/simbot/common/id/LongID;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupRecallEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$Companion;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getNoticeType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;Ljava/lang/String;JJ)V
+	public synthetic fun <init> (Llove/forte/simbot/common/id/ID;Ljava/lang/String;JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (Llove/forte/simbot/common/id/ID;Ljava/lang/String;JJ)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;Llove/forte/simbot/common/id/ID;Ljava/lang/String;JJILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBusid ()J
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getSize ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawGroupUploadEvent$FileInfo$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent : love/forte/simbot/component/onebot/v11/event/RawEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent$Companion;
+	public static final field POST_TYPE Ljava/lang/String;
+	public abstract fun getNoticeType ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent$Companion {
+	public static final field POST_TYPE Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent : love/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent$Companion;
+	public static final field SUB_TYPE_HONOR Ljava/lang/String;
+	public static final field SUB_TYPE_LUCKY_KING Ljava/lang/String;
+	public static final field SUB_TYPE_POKE Ljava/lang/String;
+	public fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)V
+	public synthetic fun <init> (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component9 ()Llove/forte/simbot/common/id/LongID;
+	public final fun copy (JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;)Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;JLlove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getHonorType ()Ljava/lang/String;
+	public fun getNoticeType ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public final fun getTargetId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent : love/forte/simbot/component/onebot/v11/event/request/RawRequestEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent$Companion;
+	public fun <init> (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent;JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getFlag ()Ljava/lang/String;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getRequestType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/request/RawFriendRequestEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent : love/forte/simbot/component/onebot/v11/event/request/RawRequestEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent$Companion;
+	public static final field SUB_TYPE_ADD Ljava/lang/String;
+	public static final field SUB_TYPE_INVITE Ljava/lang/String;
+	public fun <init> (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component7 ()Llove/forte/simbot/common/id/LongID;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent;JLjava/lang/String;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;Llove/forte/simbot/common/id/LongID;Llove/forte/simbot/common/id/LongID;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getFlag ()Ljava/lang/String;
+	public final fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public fun getPostType ()Ljava/lang/String;
+	public fun getRequestType ()Ljava/lang/String;
+	public fun getSelfId ()Llove/forte/simbot/common/id/LongID;
+	public final fun getSubType ()Ljava/lang/String;
+	public fun getTime ()J
+	public final fun getUserId ()Llove/forte/simbot/common/id/LongID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/request/RawGroupRequestEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/event/request/RawRequestEvent : love/forte/simbot/component/onebot/v11/event/RawEvent {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/event/request/RawRequestEvent$Companion;
+	public static final field POST_TYPE Ljava/lang/String;
+	public abstract fun getRequestType ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/event/request/RawRequestEvent$Companion {
+	public static final field POST_TYPE Ljava/lang/String;
+}
+

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/api/simbot-component-onebot-v11-message.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/api/simbot-component-onebot-v11-message.api
@@ -1,0 +1,1283 @@
+public abstract interface class love/forte/simbot/component/onebot/v11/message/OneBotMessageContent : love/forte/simbot/message/MessageContent {
+	public abstract fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
+	public abstract fun getMessages ()Llove/forte/simbot/message/Messages;
+	public abstract fun getPlainText ()Ljava/lang/String;
+	public abstract fun getSourceSegments ()Ljava/util/List;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/message/OneBotMessageElement : love/forte/simbot/message/Message$Element {
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/OneBotMessageElementSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/OneBotMessageElementSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/message/OneBotMessageReceipt : love/forte/simbot/message/MessageReceipt {
+	public abstract fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMessageId ()Llove/forte/simbot/common/id/ID;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement$Companion;
+	public fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;)V
+	public final fun component1 ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;
+	public final fun copy (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;)Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/DefaultOneBotMessageSegmentElement$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public static final fun create ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;
+	public static final fun create (Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIgnore ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Factory {
+	public final fun create ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;
+	public final fun create (Ljava/lang/Boolean;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous$Factory;Ljava/lang/Boolean;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAnonymous;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAt : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field ALL_QQ Ljava/lang/String;
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public static final fun createAtAll ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;
+	public fun hashCode ()I
+	public final fun isAll ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotAt$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getQq ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotAt$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public final fun createAtAll ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotAt;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotContact : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact;
+	public final fun getContactId ()Llove/forte/simbot/common/id/ID;
+	public final fun getContactType ()Ljava/lang/String;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotContact$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data$Companion;
+	public fun <init> (Ljava/lang/String;Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Ljava/lang/String;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;Ljava/lang/String;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotContact$Factory {
+	public final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotContact;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotDice : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment, love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElementResolver {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotDice;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Lkotlin/Unit;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toElement ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotDice$Element : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement, love/forte/simbot/message/MentionMessage {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotDice$Element;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotDice;
+	public synthetic fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotFace : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotFace$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotFace$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotFace;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForward : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotForward$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForward$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForward;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode;
+	public static final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data$Companion;
+	public fun <init> ()V
+	public fun <init> (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun component2 ()Llove/forte/simbot/common/id/ID;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;Llove/forte/simbot/common/id/ID;Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/util/List;
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public final fun getNickname ()Ljava/lang/String;
+	public final fun getUserId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode;
+	public final fun create (Llove/forte/simbot/common/id/ID;Ljava/lang/String;Ljava/util/List;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotForwardNode;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment, love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElementResolver {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public static final fun create (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public static final fun create (Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;
+	public final fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun hashCode ()I
+	public fun toElement ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$AdditionalParams {
+	public fun <init> ()V
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getLocalFileToBase64 ()Z
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun getType ()Ljava/lang/String;
+	public final fun setCache (Ljava/lang/Boolean;)V
+	public final fun setLocalFileToBase64 (Z)V
+	public final fun setProxy (Ljava/lang/Boolean;)V
+	public final fun setTimeout (Ljava/lang/Integer;)V
+	public final fun setType (Ljava/lang/String;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement, love/forte/simbot/message/Image, love/forte/simbot/message/UrlAwareImage {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element$Companion;
+	public fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;)V
+	public final fun component1 ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun copy (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public synthetic fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public synthetic fun url (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Element$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun create (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun create (Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Factory;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Factory;Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$AdditionalParams;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImageKt {
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Factory;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/functions/Function1;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotJson : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;
+	public final fun getXml ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotJson$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotJson$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotJson;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotLocation : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;
+	public final fun getLat ()Ljava/lang/String;
+	public final fun getLon ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getLat ()Ljava/lang/String;
+	public final fun getLon ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Factory {
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation$Factory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotLocation;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public abstract fun getData ()Ljava/lang/Object;
+}
+
+public abstract class love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement : love/forte/simbot/component/onebot/v11/message/OneBotMessageElement {
+	public fun <init> ()V
+	public abstract fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElementResolver {
+	public abstract fun toElement ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegments {
+	public static final fun add (Llove/forte/simbot/message/MessagesBuilder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;)Llove/forte/simbot/message/MessagesBuilder;
+	public static final fun toElement (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotMusic : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field CUSTOM_DATA_TYPE Ljava/lang/String;
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;
+	public final fun getMusicType ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAudio ()Ljava/lang/String;
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Factory {
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic$Factory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMusic;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotPoke : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public static final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Factory {
+	public final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public final fun create (Ljava/lang/String;Llove/forte/simbot/common/id/ID;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke$Factory;Ljava/lang/String;Llove/forte/simbot/common/id/ID;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotPoke;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public static final fun create (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public static final fun create (Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;
+	public final fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$AdditionalParams {
+	public fun <init> ()V
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getLocalFileToBase64 ()Z
+	public final fun getMagic ()Ljava/lang/String;
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun setCache (Ljava/lang/Boolean;)V
+	public final fun setLocalFileToBase64 (Z)V
+	public final fun setMagic (Ljava/lang/String;)V
+	public final fun setProxy (Ljava/lang/Boolean;)V
+	public final fun setTimeout (Ljava/lang/Integer;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getMagic ()Ljava/lang/String;
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public final fun create (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public final fun create (Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Factory;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Factory;Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$AdditionalParams;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotReply : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotReply$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data$Companion;
+	public fun <init> (Llove/forte/simbot/common/id/ID;)V
+	public final fun component1 ()Llove/forte/simbot/common/id/ID;
+	public final fun copy (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;Llove/forte/simbot/common/id/ID;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Llove/forte/simbot/common/id/ID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotReply$Factory {
+	public final fun create (Llove/forte/simbot/common/id/ID;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotReply;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRps : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRps;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Lkotlin/Unit;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotShake : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShake;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Lkotlin/Unit;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotShare : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public static final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotShare$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Factory {
+	public final fun create (Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public final fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare$Factory;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotShare;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotText : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment, love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElementResolver {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;
+	public fun hashCode ()I
+	public fun toElement ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElement, love/forte/simbot/message/PlainText {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element$Companion;
+	public fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;)V
+	public final fun component1 ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;
+	public final fun copy (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment;
+	public fun getSegment ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;
+	public fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Element$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotText$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotText;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public static final fun create (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public static final fun create (Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;
+	public final fun getResource ()Llove/forte/simbot/resource/Resource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$AdditionalParams {
+	public fun <init> ()V
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getLocalFileToBase64 ()Z
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun setCache (Ljava/lang/Boolean;)V
+	public final fun setLocalFileToBase64 (Z)V
+	public final fun setProxy (Ljava/lang/Boolean;)V
+	public final fun setTimeout (Ljava/lang/Integer;)V
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data$Companion;
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCache ()Ljava/lang/Boolean;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getProxy ()Ljava/lang/Boolean;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public final fun create (Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public final fun create (Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$AdditionalParams;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Factory;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public static synthetic fun create$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Factory;Llove/forte/simbot/resource/Resource;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$AdditionalParams;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotXml : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
+	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Factory;
+	public static final field TYPE Ljava/lang/String;
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml;
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getData ()Ljava/lang/Object;
+	public fun getData ()Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;
+	public final fun getXml ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotXml$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;
+	public static synthetic fun copy$default (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;Ljava/lang/String;ILjava/lang/Object;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public synthetic class love/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Data$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotXml$Factory {
+	public final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotXml;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+


### PR DESCRIPTION
```kotlin
val bot = ...
val api = ...

bot.execute(api)
bot.executeRaw(api)
bot.executeResult(api)
bot.executeData(api)

bot.inExecutableScope {
  api.execute()
  api.executeRaw()
  api.executeResult()
  api.executeData()
}
```