### PR TITLE
内部的默认Json实例增加属性配置 `coerceInputValues=true` 以解决非null属性遇到null值输入的问题

### DIFF
--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -37,8 +37,8 @@ object P {
         override val description: String get() = DESCRIPTION
         override val homepage: String get() = HOMEPAGE
 
-        const val VERSION = "1.1.0"
-        const val NEXT_VERSION = "1.1.1"
+        const val VERSION = "1.1.1"
+        const val NEXT_VERSION = "1.1.2"
 
         override val snapshotVersion = "$NEXT_VERSION-SNAPSHOT"
         override val version = if (isSnapshot()) snapshotVersion else VERSION

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/OneBot11.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/OneBot11.kt
@@ -85,5 +85,7 @@ public object OneBot11 {
         prettyPrint = false
         serializersModule = OneBot11.serializersModule
         allowTrailingComma = true
+        // since 1.1.1
+        coerceInputValues = true
     }
 }


### PR DESCRIPTION
fix #76