### PR TITLE
Notify事件的 groupId 变更为 nullable，并增加 OneBotGroupNotifyEvent 和 OneBotPrivatePokeEvent 用以区分群内或私聊的通知类型事件

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/api/simbot-component-onebot-v11-core.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/api/simbot-component-onebot-v11-core.api
@@ -2320,7 +2320,7 @@ public abstract interface class love/forte/simbot/component/onebot/v11/core/even
 	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/meta/RawMetaEvent;
 }
 
-public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotBotSelfPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotBotSelfPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupNotifyEvent, love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
 }
 
 public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotFriendAddEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent {
@@ -2448,6 +2448,23 @@ public abstract interface class love/forte/simbot/component/onebot/v11/core/even
 	public abstract synthetic fun member (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupNotifyEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent, love/forte/simbot/event/MemberEvent {
+	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun getContent ()Ljava/lang/Object;
+	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
+	public synthetic fun getContent ()Llove/forte/simbot/definition/Member;
+	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract fun getGroupId ()Llove/forte/simbot/common/id/LongID;
+	public synthetic fun getSource ()Ljava/lang/Object;
+	public fun getSource ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
+	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
+	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
+	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupRecallEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/ChatGroupEvent {
 	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getAuthorId ()Llove/forte/simbot/common/id/LongID;
@@ -2481,43 +2498,33 @@ public abstract interface class love/forte/simbot/component/onebot/v11/core/even
 	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
 }
 
-public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotHonorEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent {
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotHonorEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupNotifyEvent {
 	public fun getHonorType ()Ljava/lang/String;
 }
 
-public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotLuckyKingEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent {
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotLuckyKingEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupNotifyEvent {
 	public fun getTargetId ()Llove/forte/simbot/common/id/LongID;
 }
 
-public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotMemberPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotMemberPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotGroupNotifyEvent, love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
 }
 
 public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent {
 	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawNoticeEvent;
 }
 
-public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent, love/forte/simbot/event/MemberEvent {
-	public abstract synthetic fun content (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public synthetic fun getContent ()Ljava/lang/Object;
-	public fun getContent ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotMember;
-	public synthetic fun getContent ()Llove/forte/simbot/definition/Actor;
-	public synthetic fun getContent ()Llove/forte/simbot/definition/Member;
-	public fun getContentAsync ()Ljava/util/concurrent/CompletableFuture;
-	public fun getContentReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNoticeEvent {
 	public fun getGroupId ()Llove/forte/simbot/common/id/LongID;
 	public fun getHonorType ()Ljava/lang/String;
-	public synthetic fun getSource ()Ljava/lang/Object;
-	public fun getSource ()Llove/forte/simbot/component/onebot/v11/core/actor/OneBotGroup;
-	public synthetic fun getSource ()Llove/forte/simbot/definition/Organization;
-	public fun getSourceAsync ()Ljava/util/concurrent/CompletableFuture;
 	public abstract fun getSourceEvent ()Llove/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent;
-	public fun getSourceReserve ()Llove/forte/simbot/suspendrunner/reserve/SuspendReserve;
 	public fun getUserId ()Llove/forte/simbot/common/id/LongID;
-	public abstract synthetic fun source (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent {
 	public fun getTargetId ()Llove/forte/simbot/common/id/LongID;
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPrivatePokeEvent : love/forte/simbot/component/onebot/v11/core/event/notice/OneBotPokeEvent {
 }
 
 public abstract class love/forte/simbot/component/onebot/v11/core/event/request/OneBotFriendRequestAcceptOption : love/forte/simbot/ability/AcceptOption {

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
@@ -764,6 +764,7 @@ internal fun OneBotBotImpl.resolveRawEventToEvent(raw: String, event: OBRawEvent
             RawNotifyEvent.SUB_TYPE_HONOR -> OneBotHonorEventImpl(raw, event, bot)
             RawNotifyEvent.SUB_TYPE_LUCKY_KING -> OneBotLuckyKingEventImpl(raw, event, bot)
             RawNotifyEvent.SUB_TYPE_POKE -> when {
+                event.groupId == null -> OneBotPrivatePokeEventImpl(raw, event, bot)
                 event.selfId.value == event.targetId?.value ->
                     OneBotBotSelfPokeEventImpl(raw, event, bot)
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotNotifyEventImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/internal/notice/OneBotNotifyEventImpl.kt
@@ -18,6 +18,7 @@
 package love.forte.simbot.component.onebot.v11.core.event.internal.notice
 
 import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.id.LongID
 import love.forte.simbot.common.id.StringID.Companion.ID
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotGroup
 import love.forte.simbot.component.onebot.v11.core.actor.OneBotMember
@@ -40,7 +41,18 @@ internal abstract class OneBotNotifyEventImpl(
         get() = with(sourceEvent) {
             "$postType-$noticeType-$subType-$groupId-$userId-$time"
         }.ID
+}
 
+/**
+ *
+ * @author ForteScarlet
+ */
+internal abstract class OneBotGroupNotifyEventImpl(
+    override val sourceEventRaw: String?,
+    override val groupId: LongID,
+    override val sourceEvent: RawNotifyEvent,
+    override val bot: OneBotBotImpl
+) : OneBotGroupNotifyEvent, OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot) {
     override suspend fun source(): OneBotGroup {
         return bot.groupRelation.group(groupId)
             ?: error("Group with id $groupId is not found")
@@ -48,7 +60,7 @@ internal abstract class OneBotNotifyEventImpl(
 
     override suspend fun content(): OneBotMember {
         return bot.groupRelation.member(
-            groupId = sourceEvent.groupId,
+            groupId = groupId,
             memberId = sourceEvent.userId
         ) ?: error(
             "Member with id ${sourceEvent.userId} " +
@@ -61,7 +73,7 @@ internal class OneBotHonorEventImpl(
     sourceEventRaw: String?,
     sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
-) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
+) : OneBotGroupNotifyEventImpl(sourceEventRaw, sourceEvent.groupId!!, sourceEvent, bot),
     OneBotHonorEvent {
     override fun toString(): String =
         eventToString("OneBotHonorEvent")
@@ -71,7 +83,7 @@ internal class OneBotLuckyKingEventImpl(
     sourceEventRaw: String?,
     sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
-) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
+) : OneBotGroupNotifyEventImpl(sourceEventRaw, sourceEvent.groupId!!, sourceEvent, bot),
     OneBotLuckyKingEvent {
     override fun toString(): String =
         eventToString("OneBotLuckyKingEvent")
@@ -81,7 +93,7 @@ internal class OneBotMemberPokeEventImpl(
     sourceEventRaw: String?,
     sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
-) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
+) : OneBotGroupNotifyEventImpl(sourceEventRaw, sourceEvent.groupId!!, sourceEvent, bot),
     OneBotMemberPokeEvent {
     override fun toString(): String =
         eventToString("OneBotMemberPokeEvent")
@@ -91,8 +103,18 @@ internal class OneBotBotSelfPokeEventImpl(
     sourceEventRaw: String?,
     sourceEvent: RawNotifyEvent,
     bot: OneBotBotImpl
-) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
+) : OneBotGroupNotifyEventImpl(sourceEventRaw, sourceEvent.groupId!!, sourceEvent, bot),
     OneBotBotSelfPokeEvent {
     override fun toString(): String =
         eventToString("OneBotBotSelfPokeEvent")
+}
+
+internal class OneBotPrivatePokeEventImpl(
+    sourceEventRaw: String?,
+    sourceEvent: RawNotifyEvent,
+    bot: OneBotBotImpl
+) : OneBotNotifyEventImpl(sourceEventRaw, sourceEvent, bot),
+    OneBotPrivatePokeEvent {
+    override fun toString(): String =
+        eventToString("OneBotPrivatePokeEvent")
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/notice/OneBotNotifyEvent.kt
@@ -34,7 +34,7 @@ import love.forte.simbot.suspendrunner.STP
  * @see OneBotPokeEvent
  * @author ForteScarlet
  */
-public interface OneBotNotifyEvent : OneBotNoticeEvent, MemberEvent {
+public interface OneBotNotifyEvent : OneBotNoticeEvent {
     override val sourceEvent: RawNotifyEvent
 
     /**
@@ -46,9 +46,9 @@ public interface OneBotNotifyEvent : OneBotNoticeEvent, MemberEvent {
         get() = sourceEvent.honorType
 
     /**
-     * 群号
+     * 群号。如果是代表私聊相关的事件（例如私聊戳一戳）则为 `null`。
      */
-    public val groupId: LongID
+    public val groupId: LongID?
         get() = sourceEvent.groupId
 
     /**
@@ -56,6 +56,21 @@ public interface OneBotNotifyEvent : OneBotNoticeEvent, MemberEvent {
      */
     public val userId: LongID
         get() = sourceEvent.userId
+
+}
+
+/**
+ * 群成员荣誉变更事件、红包人气王事件或戳一戳事件。
+ *
+ * @see OneBotNotifyEvent
+ *
+ * @since 1.4.0
+ */
+public interface OneBotGroupNotifyEvent : OneBotNotifyEvent, MemberEvent {
+    /**
+     * 事件发送的群号
+     */
+    override val groupId: LongID
 
     /**
      * 群
@@ -72,13 +87,12 @@ public interface OneBotNotifyEvent : OneBotNoticeEvent, MemberEvent {
      */
     @STP
     override suspend fun content(): OneBotMember
-
 }
 
 /**
  * 群成员荣誉变更事件
  */
-public interface OneBotHonorEvent : OneBotNotifyEvent {
+public interface OneBotHonorEvent : OneBotGroupNotifyEvent {
     /**
      * 荣誉类型.
      *
@@ -91,7 +105,7 @@ public interface OneBotHonorEvent : OneBotNotifyEvent {
 /**
  * 群红包运气王事件
  */
-public interface OneBotLuckyKingEvent : OneBotNotifyEvent {
+public interface OneBotLuckyKingEvent : OneBotGroupNotifyEvent {
     /**
      * 人气王用户ID
      */
@@ -100,7 +114,7 @@ public interface OneBotLuckyKingEvent : OneBotNotifyEvent {
 }
 
 /**
- * 群戳一戳事件
+ * 戳一戳事件
  *
  * @see OneBotMemberPokeEvent
  * @see OneBotBotSelfPokeEvent
@@ -116,9 +130,16 @@ public interface OneBotPokeEvent : OneBotNotifyEvent {
 /**
  * 群里Bot以外的群成员被戳一戳事件
  */
-public interface OneBotMemberPokeEvent : OneBotPokeEvent
+public interface OneBotMemberPokeEvent : OneBotPokeEvent, OneBotGroupNotifyEvent
 
 /**
  * 群里Bot被戳一戳事件，即 [targetId] == [selfId]。
  */
-public interface OneBotBotSelfPokeEvent : OneBotPokeEvent
+public interface OneBotBotSelfPokeEvent : OneBotPokeEvent, OneBotGroupNotifyEvent
+
+/**
+ * 私聊里的戳一戳事件，[groupId] == `null`。
+ *
+ * @since 1.4.0
+ */
+public interface OneBotPrivatePokeEvent : OneBotPokeEvent

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/notice/RawNotifyEvent.kt
@@ -33,7 +33,7 @@ import love.forte.simbot.component.onebot.v11.event.ExpectEventType
  *
  * @property subType 提示类型。
  * 可能的值: `honor`, `lucky_king`, `poke`
- * @property groupId 群号。
+ * @property groupId 群号。如果是代表私聊相关的事件（例如私聊戳一戳）则为 `null`。
  * @property honorType 荣誉类型，分别表示龙王、群聊之火、快乐源泉。
  * 可能的值: `talkative`、`performer`、`emotion`。
  * 当 [subType] 为 `honor` 时有值。
@@ -57,7 +57,7 @@ public data class RawNotifyEvent(
     @SerialName("sub_type")
     public val subType: String,
     @SerialName("group_id")
-    public val groupId: LongID,
+    public val groupId: LongID? = null,
     @SerialName("honor_type")
     public val honorType: String? = null,
     @SerialName("user_id")


### PR DESCRIPTION
增加事件类型的同时对部分字段的可空性和继承关系做了调整，一定程度上与之前不兼容。

See also: https://github.com/simple-robot/simpler-robot/issues/928
