### PR TITLE
尝试修复由于编译器插件导致的IDE泛型解析问题，进而导致的 OneBotApiExecutable 合成函数在IDEA中不可见的问题

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ setup(P.ComponentOneBot)
 buildscript {
     repositories {
         mavenCentral()
+        mavenLocal()
     }
 }
 
@@ -51,6 +52,7 @@ allprojects {
                 snapshotsOnly()
             }
         }
+        mavenLocal()
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.21"
+kotlin = "2.0.20"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.7.3"
 kotlinx-io = "0.5.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.20"
+kotlin = "2.0.21"
 kotlinx-coroutines = "1.9.0"
 kotlinx-serialization = "1.7.3"
 kotlinx-io = "0.5.4"
@@ -9,7 +9,7 @@ openjdk-jmh = "1.37"
 log4j = "2.24.1"
 # simbot
 simbot = "4.7.0"
-suspendTransform = "2.0.20-0.9.3"
+suspendTransform = "2.0.21-0.9.4"
 gradleCommon = "0.6.0"
 # ksp
 ksp = "2.0.20-1.0.25"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ openjdk-jmh = "1.37"
 log4j = "2.24.1"
 # simbot
 simbot = "4.7.0"
-suspendTransform = "2.0.21-0.9.4"
+suspendTransform = "2.0.20-0.9.4"
 gradleCommon = "0.6.0"
 # ksp
 ksp = "2.0.20-1.0.25"


### PR DESCRIPTION
see #139