### PR TITLE
对图片、视频、语音文件进行base64编码时，默认使用 Base64.Default 进行编码

### DIFF
--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/api/simbot-component-onebot-v11-message.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/api/simbot-component-onebot-v11-message.api
@@ -1,3 +1,14 @@
+public abstract interface class love/forte/simbot/component/onebot/v11/message/Base64Encoder {
+	public static final field Companion Llove/forte/simbot/component/onebot/v11/message/Base64Encoder$Companion;
+	public static final field Default Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;
+	public static final field Mime Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;
+	public static final field UrlSafe Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;
+	public abstract fun encodeToAppendable ([BLjava/lang/Appendable;)Ljava/lang/Appendable;
+}
+
+public final class love/forte/simbot/component/onebot/v11/message/Base64Encoder$Companion {
+}
+
 public abstract interface class love/forte/simbot/component/onebot/v11/message/OneBotMessageContent : love/forte/simbot/message/MessageContent {
 	public abstract synthetic fun delete ([Llove/forte/simbot/ability/DeleteOption;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getId ()Llove/forte/simbot/common/id/ID;
@@ -427,7 +438,7 @@ public final class love/forte/simbot/component/onebot/v11/message/segment/OneBot
 public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment, love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegmentElementResolver {
 	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Factory;
 	public static final field TYPE Ljava/lang/String;
-	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
 	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
 	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotImage;
@@ -455,11 +466,13 @@ public synthetic class love/forte/simbot/component/onebot/v11/message/segment/On
 
 public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotImage$AdditionalParams {
 	public fun <init> ()V
+	public final fun getBase64Encoder ()Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;
 	public final fun getCache ()Ljava/lang/Boolean;
 	public final fun getLocalFileToBase64 ()Z
 	public final fun getProxy ()Ljava/lang/Boolean;
 	public final fun getTimeout ()Ljava/lang/Integer;
 	public final fun getType ()Ljava/lang/String;
+	public final fun setBase64Encoder (Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;)V
 	public final fun setCache (Ljava/lang/Boolean;)V
 	public final fun setLocalFileToBase64 (Z)V
 	public final fun setProxy (Ljava/lang/Boolean;)V
@@ -836,7 +849,7 @@ public final class love/forte/simbot/component/onebot/v11/message/segment/OneBot
 public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
 	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Factory;
 	public static final field TYPE Ljava/lang/String;
-	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
 	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
 	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotRecord;
@@ -863,11 +876,13 @@ public synthetic class love/forte/simbot/component/onebot/v11/message/segment/On
 
 public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord$AdditionalParams {
 	public fun <init> ()V
+	public final fun getBase64Encoder ()Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;
 	public final fun getCache ()Ljava/lang/Boolean;
 	public final fun getLocalFileToBase64 ()Z
 	public final fun getMagic ()Ljava/lang/String;
 	public final fun getProxy ()Ljava/lang/Boolean;
 	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun setBase64Encoder (Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;)V
 	public final fun setCache (Ljava/lang/Boolean;)V
 	public final fun setLocalFileToBase64 (Z)V
 	public final fun setMagic (Ljava/lang/String;)V
@@ -1143,7 +1158,7 @@ public final class love/forte/simbot/component/onebot/v11/message/segment/OneBot
 public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo : love/forte/simbot/component/onebot/v11/message/segment/OneBotMessageSegment {
 	public static final field Factory Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Factory;
 	public static final field TYPE Ljava/lang/String;
-	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;Ljava/lang/String;Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Ljava/lang/String;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
 	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
 	public static final fun create (Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$Data;Llove/forte/simbot/resource/Resource;)Llove/forte/simbot/component/onebot/v11/message/segment/OneBotVideo;
@@ -1170,10 +1185,12 @@ public synthetic class love/forte/simbot/component/onebot/v11/message/segment/On
 
 public final class love/forte/simbot/component/onebot/v11/message/segment/OneBotVideo$AdditionalParams {
 	public fun <init> ()V
+	public final fun getBase64Encoder ()Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;
 	public final fun getCache ()Ljava/lang/Boolean;
 	public final fun getLocalFileToBase64 ()Z
 	public final fun getProxy ()Ljava/lang/Boolean;
 	public final fun getTimeout ()Ljava/lang/Integer;
+	public final fun setBase64Encoder (Llove/forte/simbot/component/onebot/v11/message/Base64Encoder;)V
 	public final fun setCache (Ljava/lang/Boolean;)V
 	public final fun setLocalFileToBase64 (Z)V
 	public final fun setProxy (Ljava/lang/Boolean;)V

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/message/Base64Encoder.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/message/Base64Encoder.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025. ForteScarlet.
+ *
+ * This file is part of simbot-component-onebot.
+ *
+ * simbot-component-onebot is free software: you can redistribute it and/or modify it under the terms
+ * of the GNU Lesser General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * simbot-component-onebot is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with simbot-component-onebot.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package love.forte.simbot.component.onebot.v11.message
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.jvm.JvmField
+
+
+/**
+ * A base64 encoder.
+ *
+ * @since 1.6.1
+ *
+ * @author ForteScarlet
+ */
+public interface Base64Encoder {
+    /**
+     * Encodes [source] ByteArray to a Base64 encoded ByteArray.
+     */
+    public fun <A : Appendable> encodeToAppendable(source: ByteArray, destination: A): A
+
+    public companion object {
+        /**
+         * Get a [Base64Encoder] instance based on [kotlin.io.encoding.Base64.Default].
+         */
+        @ExperimentalEncodingApi
+        @JvmField
+        public val Default: Base64Encoder = KotlinBase64Encoder(Base64.Default)
+
+        /**
+         * Get a [Base64Encoder] instance based on [kotlin.io.encoding.Base64.Mime].
+         */
+        @ExperimentalEncodingApi
+        @JvmField
+        public val Mime: Base64Encoder = KotlinBase64Encoder(Base64.Mime)
+
+        /**
+         * Get a [Base64Encoder] instance based on [kotlin.io.encoding.Base64.UrlSafe].
+         */
+        @ExperimentalEncodingApi
+        @JvmField
+        public val UrlSafe: Base64Encoder = KotlinBase64Encoder(Base64.UrlSafe)
+    }
+}
+
+@ExperimentalEncodingApi
+private class KotlinBase64Encoder(val base64: Base64) : Base64Encoder {
+    override fun <A : Appendable> encodeToAppendable(source: ByteArray, destination: A): A {
+        base64.encodeToAppendable(source, destination)
+        return destination
+    }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+internal fun standardEncoderByName(name: String): Base64Encoder? {
+    return when {
+        name.equals("Default", true) -> Base64Encoder.Default
+        name.equals("Mime", true) -> Base64Encoder.Mime
+        name.equals("UrlSafe", true) || name.equals("url_safe", true)
+        -> Base64Encoder.UrlSafe
+
+        else -> null
+    }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+internal fun Base64Encoder.standardName(): String? {
+    return when (this) {
+        Base64Encoder.Default -> "Default"
+        Base64Encoder.Mime -> "Mime"
+        Base64Encoder.UrlSafe -> "UrlSafe"
+        else -> null
+    }
+}
+
+@OptIn(ExperimentalEncodingApi::class)
+internal val Base64Encoder.base64: Base64? get() = (this as? KotlinBase64Encoder)?.base64

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/OneBotRecord.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2025. ForteScarlet.
  *
  * This file is part of simbot-component-onebot.
  *
@@ -20,8 +20,13 @@ package love.forte.simbot.component.onebot.v11.message.segment
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
+import love.forte.simbot.component.onebot.v11.message.Base64Encoder
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotRecord.Factory.create
+import love.forte.simbot.component.onebot.v11.message.standardEncoderByName
+import love.forte.simbot.component.onebot.v11.message.standardName
 import love.forte.simbot.resource.ByteArrayResource
 import love.forte.simbot.resource.Resource
+import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
@@ -38,6 +43,11 @@ public class OneBotRecord private constructor(
     override val data: Data,
     @Transient
     private val resource0: Resource? = null,
+    private val base64Encoder: String? = null,
+    @Transient
+    @OptIn(ExperimentalEncodingApi::class)
+    private val base64EncoderValue: Base64Encoder =
+        base64Encoder?.let { standardEncoderByName(it) } ?: Base64Encoder.Default
 ) : OneBotMessageSegment {
     /**
      * 当前 [OneBotRecord] 中的资源信息。
@@ -46,14 +56,14 @@ public class OneBotRecord private constructor(
      * [Data.file] 的资源信息。
      */
     public val resource: Resource by lazy {
-        resource0 ?: data.resolveToResource()
+        resource0 ?: data.resolveToResource(base64EncoderValue)
     }
 
     public companion object Factory {
         public const val TYPE: String = "record"
 
-        private fun Data.resolveToResource(): Resource {
-            return resolveUrlOrFileToResource(url, file)
+        private fun Data.resolveToResource(encoder: Base64Encoder): Resource {
+            return resolveUrlOrFileToResource(url, file, encoder)
         }
 
         /**
@@ -63,6 +73,9 @@ public class OneBotRecord private constructor(
          * - 如果 [Data.file] 是 base64 格式，解析为 [ByteArrayResource]。
          * - 如果 [Data.file] 是链接或者文件路径，
          * 解析为 `URIResource` 或 `PathResource` （仅支持 JVM 平台）
+         *
+         * 如果需要指定 [Base64Encoder] (since 1.6.1),
+         * 选择使用 [create] 的另一个可以提供 [AdditionalParams] 的重载。
          *
          * @throws UnsupportedOperationException 如果解析 [resource] 时平台不支持
          */
@@ -97,9 +110,12 @@ public class OneBotRecord private constructor(
         @JvmStatic
         @JvmOverloads
         public fun create(resource: Resource, additional: AdditionalParams? = null): OneBotRecord {
+            val base64Encoder = additional.base64EncoderOrDefault
+
             val file = resolveResourceToFileValue(
                 resource,
-                additional?.localFileToBase64 == true
+                additional?.localFileToBase64 == true,
+                base64Encoder
             )
 
             val data = Data(
@@ -110,7 +126,7 @@ public class OneBotRecord private constructor(
                 timeout = additional?.timeout,
             )
 
-            return OneBotRecord(data, resource)
+            return OneBotRecord(data, resource, base64Encoder.standardName(), base64Encoder)
         }
     }
 
@@ -139,6 +155,13 @@ public class OneBotRecord private constructor(
      */
     public class AdditionalParams {
         public var localFileToBase64: Boolean = false
+
+        /**
+         * 当需要对资源进行 base64 编码时使用的编码器。
+         * 如果未配置则默认为 [Base64Encoder.Default]。
+         * @since 1.6.1
+         */
+        public var base64Encoder: Base64Encoder? = null
         public var magic: String? = null
         public var cache: Boolean? = null
         public var proxy: Boolean? = null
@@ -165,3 +188,7 @@ public class OneBotRecord private constructor(
         return "OneBotRecord(data=$data)"
     }
 }
+
+@OptIn(ExperimentalEncodingApi::class)
+private inline val OneBotRecord.AdditionalParams?.base64EncoderOrDefault: Base64Encoder
+    get() = this?.base64Encoder ?: Base64Encoder.Default

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/message/ResourceMessageBase64Tests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/message/ResourceMessageBase64Tests.kt
@@ -1,0 +1,88 @@
+package love.forte.simbot.component.onebot.v11.message
+
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotRecord
+import love.forte.simbot.component.onebot.v11.message.segment.OneBotVideo
+import love.forte.simbot.resource.toResource
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class ResourceMessageBase64Tests {
+    companion object {
+        private const val BASE64_D = "qr6f9jnXeM/3txdpG94OQA=="
+        private const val BASE64_U = "qr6f9jnXeM_3txdpG94OQA=="
+
+        @OptIn(ExperimentalStdlibApi::class)
+        private val original = "AABE9FF639D778CFF7B717691BDE0E40".hexToByteArray()
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun imageBase64DefaultTest() {
+        assertEquals(
+            "base64://$BASE64_D",
+            OneBotImage.create(
+                original.toResource(),
+            ).data.file
+        )
+
+        assertEquals(
+            "base64://$BASE64_U",
+            OneBotImage.create(
+                original.toResource(),
+                OneBotImage.AdditionalParams().apply {
+                    base64Encoder = Base64Encoder.UrlSafe
+                }
+            ).data.file
+        )
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun videoBase64DefaultTest() {
+        assertEquals(
+            "base64://$BASE64_D",
+            OneBotVideo.create(
+                original.toResource(),
+            ).data.file
+        )
+
+        assertEquals(
+            "base64://$BASE64_U",
+            OneBotVideo.create(
+                original.toResource(),
+                OneBotVideo.AdditionalParams().apply {
+                    base64Encoder = Base64Encoder.UrlSafe
+                }
+            ).data.file
+        )
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun recordBase64DefaultTest() {
+        assertEquals(
+            "base64://$BASE64_D",
+            OneBotRecord.create(
+                original.toResource(),
+            ).data.file
+        )
+
+        assertEquals(
+            "base64://$BASE64_U",
+            OneBotRecord.create(
+                original.toResource(),
+                OneBotRecord.AdditionalParams().apply {
+                    base64Encoder = Base64Encoder.UrlSafe
+                }
+            ).data.file
+        )
+    }
+
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/jsMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/StandardOneBotMessageSegments.js.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/jsMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/StandardOneBotMessageSegments.js.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2025. ForteScarlet.
  *
  * This file is part of simbot-component-onebot.
  *
@@ -17,11 +17,13 @@
 
 package love.forte.simbot.component.onebot.v11.message.segment
 
+import love.forte.simbot.component.onebot.v11.message.Base64Encoder
 import love.forte.simbot.resource.Resource
 
 internal actual fun resolveResourceToFileValuePlatform(
     resource: Resource,
     localFileToBase64: Boolean,
+    encoder: Base64Encoder
 ): String? = null
 
 internal actual fun uriResource(uri: String): Resource {

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/jvmMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/StandardOneBotMessageSegments.jvm.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/jvmMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/StandardOneBotMessageSegments.jvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2025. ForteScarlet.
  *
  * This file is part of simbot-component-onebot.
  *
@@ -17,6 +17,7 @@
 
 package love.forte.simbot.component.onebot.v11.message.segment
 
+import love.forte.simbot.component.onebot.v11.message.Base64Encoder
 import love.forte.simbot.resource.*
 import java.net.URI
 import java.nio.file.Path
@@ -28,10 +29,11 @@ import kotlin.io.path.toPath
 internal actual fun resolveResourceToFileValuePlatform(
     resource: Resource,
     localFileToBase64: Boolean,
+    encoder: Base64Encoder
 ): String? {
     fun Path.resolvePath(): String {
         return if (localFileToBase64) {
-            computeBase64FileValue(readBytes())
+            computeBase64FileValue(readBytes(), encoder)
         } else {
             absolutePathString()
         }
@@ -51,7 +53,7 @@ internal actual fun resolveResourceToFileValuePlatform(
         is FileResource -> {
             val file = resource.file
             if (localFileToBase64) {
-                computeBase64FileValue(file.readBytes())
+                computeBase64FileValue(file.readBytes(), encoder)
             } else {
                 file.absolutePath
             }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/nativeMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/StandardOneBotMessageSegments.native.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-message/src/nativeMain/kotlin/love/forte/simbot/component/onebot/v11/message/segment/StandardOneBotMessageSegments.native.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024. ForteScarlet.
+ * Copyright (c) 2024-2025. ForteScarlet.
  *
  * This file is part of simbot-component-onebot.
  *
@@ -17,11 +17,13 @@
 
 package love.forte.simbot.component.onebot.v11.message.segment
 
+import love.forte.simbot.component.onebot.v11.message.Base64Encoder
 import love.forte.simbot.resource.Resource
 
 internal actual fun resolveResourceToFileValuePlatform(
     resource: Resource,
     localFileToBase64: Boolean,
+    encoder: Base64Encoder
 ): String? = null
 
 internal actual fun uriResource(uri: String): Resource {


### PR DESCRIPTION
为 `OneBotImage.AdditionalParams`, `OneBotVideo.AdditionalParams`, `OneBotRecord.AdditionalParams` 添加新的属性：`base64Encoder: Base64Encoder` 以支持提供一个具体的 Base64 编码器，并在默认未指定的情况下使用基于 `Base64.Default` 的编码器。

```Kotlin
val image = OneBotImage.create(
                resource = resource,
                additional = OneBotImage.AdditionalParams().apply {
                    // 指定一个具体的编码器
                    base64Encoder = Base64Encoder.UrlSafe
                }
            )
```

> [!warning]
> 在之前内部默认的编码器是 `Base64.UrlSafe`, 因此会产生与之前的不同行为。

resolve #188