### PR TITLE
支持注册自定义事件解析器

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,9 @@ apiValidation {
             "love.forte.simbot.annotations.InternalSimbotAPI",
             "love.forte.simbot.component.onebot.common.annotations.ApiResultConstructor",
             "love.forte.simbot.component.onebot.common.annotations.SourceEventConstructor",
+
+            // CustomEventResolver
+            "love.forte.simbot.component.onebot.v11.core.event.ExperimentalCustomEventResolverApi"
         ),
     )
 

--- a/buildSrc/src/main/kotlin/P.kt
+++ b/buildSrc/src/main/kotlin/P.kt
@@ -37,8 +37,8 @@ object P {
         override val description: String get() = DESCRIPTION
         override val homepage: String get() = HOMEPAGE
 
-        const val VERSION = "1.7.0"
-        const val NEXT_VERSION = "1.7.1"
+        const val VERSION = "1.8.0"
+        const val NEXT_VERSION = "1.8.0"
 
         override val snapshotVersion = "$NEXT_VERSION-SNAPSHOT"
         override val version = if (isSnapshot()) snapshotVersion else VERSION

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/api/simbot-component-onebot-v11-core.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/api/simbot-component-onebot-v11-core.api
@@ -2125,6 +2125,29 @@ public final class love/forte/simbot/component/onebot/v11/core/component/OneBot1
 	public static synthetic fun useOneBot11Component$default (Llove/forte/simbot/application/ApplicationFactoryConfigurer;Llove/forte/simbot/common/function/ConfigurerFunction;ILjava/lang/Object;)V
 }
 
+public class love/forte/simbot/component/onebot/v11/core/event/CustomEventResolveException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface class love/forte/simbot/component/onebot/v11/core/event/CustomEventResolver$Context {
+	public abstract fun getBot ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
+	public abstract fun getJson ()Lkotlinx/serialization/json/Json;
+	public abstract fun getRawEventResolveResult ()Llove/forte/simbot/component/onebot/v11/core/event/RawEventResolveResult;
+}
+
+public class love/forte/simbot/component/onebot/v11/core/event/EventResolveException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
+public abstract interface annotation class love/forte/simbot/component/onebot/v11/core/event/ExperimentalCustomEventResolverApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface class love/forte/simbot/component/onebot/v11/core/event/OneBotBotEvent : love/forte/simbot/component/onebot/v11/core/event/OneBotEvent, love/forte/simbot/event/BotEvent {
 	public abstract fun getBot ()Llove/forte/simbot/component/onebot/v11/core/bot/OneBotBot;
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
@@ -59,10 +59,21 @@ kotlin {
     applyTier3(supportKtorClient = true)
 
     sourceSets {
+        configureEach {
+            if (this.name == "jvmMain") {
+                dependencies {
+                    compileOnly(libs.simbot.api)
+                }
+            } else {
+                dependencies {
+                    implementation(libs.simbot.api)
+                }
+            }
+        }
         commonMain.dependencies {
             // JVM compileOnly
-            implementation(libs.simbot.api)
-            implementation(libs.jetbrains.annotations)
+            // implementation(libs.simbot.api)
+            api(libs.jetbrains.annotations)
 
             api(libs.simbot.common.annotations)
             implementation(libs.simbot.common.atomic)
@@ -92,9 +103,11 @@ kotlin {
 
         jvmMain {
             dependencies {
-                compileOnly(libs.simbot.api)
-                compileOnly(libs.ktor.client.contentNegotiation)
-                compileOnly(libs.jetbrains.annotations)
+                // api(libs.simbot.api)
+                // api(libs.jetbrains.annotations)
+                // compileOnly(libs.simbot.api)
+                // compileOnly(libs.ktor.client.contentNegotiation)
+                // compileOnly(libs.jetbrains.annotations)
             }
         }
 
@@ -105,9 +118,13 @@ kotlin {
             implementation(libs.log4j.slf4j2)
             implementation(libs.kotlinPoet)
             implementation(libs.kotlinx.coroutines.reactor)
-            api(libs.ktor.client.java)
+            implementation(libs.ktor.client.java)
             implementation(libs.ktor.server.netty)
             implementation(libs.ktor.server.ws)
+        }
+
+        appleTest.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
     }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
@@ -62,7 +62,7 @@ kotlin {
         commonMain.dependencies {
             // JVM compileOnly
             implementation(libs.simbot.api)
-            api(libs.jetbrains.annotations)
+            implementation(libs.jetbrains.annotations)
 
             api(libs.simbot.common.annotations)
             implementation(libs.simbot.common.atomic)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
@@ -113,6 +113,12 @@ kotlin {
         appleTest.dependencies {
             implementation(libs.ktor.client.darwin)
         }
+        mingwTest.dependencies {
+            implementation(libs.ktor.client.winhttp)
+        }
+        linuxTest.dependencies {
+            implementation(libs.ktor.client.cio)
+        }
     }
 }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/build.gradle.kts
@@ -59,20 +59,9 @@ kotlin {
     applyTier3(supportKtorClient = true)
 
     sourceSets {
-        configureEach {
-            if (this.name == "jvmMain") {
-                dependencies {
-                    compileOnly(libs.simbot.api)
-                }
-            } else {
-                dependencies {
-                    implementation(libs.simbot.api)
-                }
-            }
-        }
         commonMain.dependencies {
             // JVM compileOnly
-            // implementation(libs.simbot.api)
+            implementation(libs.simbot.api)
             api(libs.jetbrains.annotations)
 
             api(libs.simbot.common.annotations)
@@ -103,11 +92,9 @@ kotlin {
 
         jvmMain {
             dependencies {
-                // api(libs.simbot.api)
-                // api(libs.jetbrains.annotations)
-                // compileOnly(libs.simbot.api)
-                // compileOnly(libs.ktor.client.contentNegotiation)
-                // compileOnly(libs.jetbrains.annotations)
+                compileOnly(libs.simbot.api)
+                compileOnly(libs.ktor.client.contentNegotiation)
+                compileOnly(libs.jetbrains.annotations)
             }
         }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApi.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/api/OneBotApi.kt
@@ -52,7 +52,7 @@ public interface OneBotApi<T : Any> {
     public val resultDeserializer: DeserializationStrategy<T>
 
     /**
-     * 预期结果 [OneBotApi] 类型的反序列化器。
+     * 预期结果 [OneBotApiResult] 类型的反序列化器。
      */
     public val apiResultDeserializer: DeserializationStrategy<OneBotApiResult<T>>
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBot.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBot.kt
@@ -43,6 +43,7 @@ import love.forte.simbot.component.onebot.v11.message.OneBotMessageContent
 import love.forte.simbot.event.EventResult
 import love.forte.simbot.message.MessageReference
 import love.forte.simbot.suspendrunner.ST
+import org.intellij.lang.annotations.Language
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmSynthetic
 
@@ -200,14 +201,14 @@ public interface OneBotBot : Bot, OneBotApiExecutable {
      *
      * @throws IllegalArgumentException 如果事件解析失败
      */
-    public fun push(rawEvent: String): Flow<EventResult>
+    public fun push(@Language("json") rawEvent: String): Flow<EventResult>
 
     /**
      * 直接推送一个外部的原始事件字符串，并在异步任务中处理事件。
      *
      * @throws IllegalArgumentException 如果事件解析失败
      */
-    public fun pushAndLaunch(rawEvent: String): Job =
+    public fun pushAndLaunch(@Language("json") rawEvent: String): Job =
         push(rawEvent).launchIn(this)
 
     /**

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration.kt
@@ -282,7 +282,9 @@ public class OneBotBotConfiguration {
  * @since 1.8.0
  */
 @ExperimentalCustomEventResolverApi
-public fun OneBotBotConfiguration.addCustomKotlinSerializationEventResolver(resolver: CustomKotlinSerializationEventResolver) {
+public fun OneBotBotConfiguration.addCustomKotlinSerializationEventResolver(
+    resolver: CustomKotlinSerializationEventResolver
+) {
     addCustomEventResolver(resolver)
 }
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/OneBotBotConfiguration.kt
@@ -21,12 +21,17 @@ import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.*
 import io.ktor.http.*
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.modules.SerializersModule
 import kotlinx.serialization.modules.overwriteWith
 import love.forte.simbot.common.function.ConfigurerFunction
 import love.forte.simbot.common.function.invokeBy
 import love.forte.simbot.component.onebot.common.annotations.ExperimentalOneBotAPI
+import love.forte.simbot.component.onebot.v11.core.event.CustomEventResolver
+import love.forte.simbot.component.onebot.v11.core.event.CustomKotlinSerializationEventResolver
+import love.forte.simbot.component.onebot.v11.core.event.ExperimentalCustomEventResolverApi
 import love.forte.simbot.component.onebot.v11.message.segment.OneBotImage
+import love.forte.simbot.event.Event
 import love.forte.simbot.resource.Resource
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -251,5 +256,55 @@ public class OneBotBotConfiguration {
     @ExperimentalOneBotAPI
     public fun defaultImageAdditionalParams(params: OneBotImage.AdditionalParams?) {
         defaultImageAdditionalParamsProvider = { params }
+    }
+
+    /**
+     *
+     * @since 1.8.0
+     */
+    @ExperimentalCustomEventResolverApi
+    internal val customEventResolvers: MutableList<CustomEventResolver> = mutableListOf()
+
+    /**
+     * 注册一个 [CustomEventResolver]。
+     * @since 1.8.0
+     */
+    @ExperimentalCustomEventResolverApi
+    public fun addCustomEventResolver(customEventResolver: CustomEventResolver) {
+        customEventResolvers.add(customEventResolver)
+    }
+}
+
+/**
+ * 添加一个 [CustomKotlinSerializationEventResolver]。
+ *
+ * @see OneBotBotConfiguration.addCustomEventResolver
+ * @since 1.8.0
+ */
+@ExperimentalCustomEventResolverApi
+public fun OneBotBotConfiguration.addCustomKotlinSerializationEventResolver(resolver: CustomKotlinSerializationEventResolver) {
+    addCustomEventResolver(resolver)
+}
+
+/**
+ * 添加一个 [CustomKotlinSerializationEventResolver]。
+ * 原则上通过 `postType` 和 `subType` 可以定位唯一一个事件类型。
+ *
+ * @see OneBotBotConfiguration.addCustomEventResolver
+ * @since 1.8.0
+ */
+@ExperimentalCustomEventResolverApi
+public inline fun OneBotBotConfiguration.addCustomKotlinSerializationEventResolver(
+    postType: String,
+    subType: String,
+    crossinline deserializationStrategy: () -> DeserializationStrategy<Event>
+) {
+    addCustomKotlinSerializationEventResolver { context ->
+        val rawEventResolveResult = context.rawEventResolveResult
+        if (rawEventResolveResult.postType == postType && rawEventResolveResult.subType == subType) {
+            deserializationStrategy()
+        } else {
+            null
+        }
     }
 }

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
@@ -756,6 +756,7 @@ private data class CustomEventResolverContextImpl(
 /**
  * 解析数据包字符串为 [Event]。
  */
+@ExperimentalCustomEventResolverApi
 internal fun OneBotBotImpl.resolveRawEvent(text: String): RawEventResolveResult {
     val obj = OneBot11.DefaultJson.decodeFromString(JsonObject.serializer(), text)
 

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/OneBotBotImpl.kt
@@ -702,7 +702,7 @@ internal fun OneBotBotImpl.resolveEvent(text: String): Event {
         }
 
         if (errors.isNotEmpty()) {
-            val newError = CustomEventResolveException("There're some errors occurred when resolving custom event.")
+            val newError = CustomEventResolveException("Some errors occurred while resolving custom events.")
             errors.forEach { newError.addSuppressed(it) }
             error = error?.also {
                 it.addSuppressed(newError)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/RawEventResolveResultImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/RawEventResolveResultImpl.kt
@@ -1,0 +1,22 @@
+package love.forte.simbot.component.onebot.v11.core.bot.internal
+
+import kotlinx.serialization.json.JsonObject
+import love.forte.simbot.common.id.LongID
+import love.forte.simbot.component.onebot.v11.core.event.RawEventResolveResult
+import love.forte.simbot.component.onebot.v11.event.RawEvent
+
+/**
+ * 一个事件文本被进行解析后的主要内容。
+ *
+ * @author ForteScarlet
+ */
+internal data class RawEventResolveResultImpl(
+    override val text: String,
+    override val json: JsonObject,
+    override val postType: String,
+    override val subType: String?,
+    override val time: Long?,
+    override val selfId: LongID?,
+    override val rawEvent: RawEvent?,
+    override val reason: Throwable?
+) : RawEventResolveResult

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/RawEventResolveResultImpl.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/bot/internal/RawEventResolveResultImpl.kt
@@ -2,6 +2,7 @@ package love.forte.simbot.component.onebot.v11.core.bot.internal
 
 import kotlinx.serialization.json.JsonObject
 import love.forte.simbot.common.id.LongID
+import love.forte.simbot.component.onebot.v11.core.event.ExperimentalCustomEventResolverApi
 import love.forte.simbot.component.onebot.v11.core.event.RawEventResolveResult
 import love.forte.simbot.component.onebot.v11.event.RawEvent
 
@@ -10,6 +11,7 @@ import love.forte.simbot.component.onebot.v11.event.RawEvent
  *
  * @author ForteScarlet
  */
+@ExperimentalCustomEventResolverApi
 internal data class RawEventResolveResultImpl(
     override val text: String,
     override val json: JsonObject,

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolveException.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolveException.kt
@@ -1,0 +1,17 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+/**
+ * 当 [CustomEventResolver] 发生异常时，
+ * 异常会被收集到 [CustomEventResolveException.suppressedExceptions] 中，
+ * 并被最终输出。
+ *
+ * @since 1.8.0
+ *
+ * @author ForteScarlet
+ */
+public open class CustomEventResolveException : RuntimeException {
+    public constructor() : super()
+    public constructor(cause: Throwable?) : super(cause)
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolver.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolver.kt
@@ -1,0 +1,66 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+import kotlinx.serialization.json.Json
+import love.forte.simbot.component.onebot.v11.core.OneBot11
+import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
+import love.forte.simbot.event.Event
+
+/**
+ * 自定义事件解析器。根据得到的初步解析结果，将事件内容解析为一个 [Event]。
+ *
+ * 当存在多个自定义解析器，则会在**首次**得到非 `null` 结果时终止处理。
+ *
+ * 如果处理链上得到的全部都为 `null`，则会在 [RawEventResolveResult.rawEvent]
+ *  不为 `null` 的情况下尝试解析为标准事件。如果无法解析，则最终会被解析为
+ *  [love.forte.simbot.component.onebot.v11.event.UnknownEvent] 和对应的
+ *  [OneBotUnknownEvent]。
+ *
+ * ### 异常
+ *
+ * 如果 [resolve] 产生异常，此异常会被暂时记录，并继续尝试使用其他解析器。
+ * 如果最终所有的 [CustomEventResolver] 都无法得到有效的结果，则：
+ * - 如果 [RawEventResolveResult.rawEvent] 不为 `null`，则会尝试解析为标准事件。
+ *   - 如果解析成功，则记录的异常会以 **异常日志** 的形式输出。
+ *   - 如果解析失败，则会使用 [OneBotUnsupportedEvent] 进行包装，记录的异常会以 **异常日志** 的形式输出。
+ * - 如果 [RawEventResolveResult.rawEvent] 为 `null`，则会使用 [OneBotUnknownEvent] 进行包装，
+ * 记录的异常会以被整合并填充到 [love.forte.simbot.component.onebot.v11.event.UnknownEvent.reason] 中，
+ * 并以 **异常日志** 的形式输出。
+ *
+ * @see CustomEventResolveException
+ * @since 1.8.0
+ * @author ForteScarlet
+ */
+@ExperimentalCustomEventResolverApi
+public fun interface CustomEventResolver {
+
+    /**
+     * 根据提供的内容信息，解析得到一个 [Event]。
+     *
+     * @return 解析结果。如果跳过解析则返回 `null`。
+     * @throws Exception 解析过程可能出现的异常。
+     */
+    @Throws(Exception::class)
+    public fun resolve(context: Context): Event?
+
+    /**
+     * 提供给 [CustomEventResolver.resolve] 进行处理的内容。
+     */
+    public interface Context {
+        /**
+         * 当前的 [OneBotBot] 对象。
+         */
+        public val bot: OneBotBot
+
+        /**
+         * 可用于解析JSON的解析器。
+         *
+         * @see OneBot11.DefaultJson
+         */
+        public val json: Json
+
+        /**
+         * 对原始事件内容的初步解析结果。
+         */
+        public val rawEventResolveResult: RawEventResolveResult
+    }
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomKotlinSerializationEventResolver.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomKotlinSerializationEventResolver.kt
@@ -1,0 +1,24 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+import kotlinx.serialization.DeserializationStrategy
+import love.forte.simbot.event.Event
+
+/**
+ * 基于 Kotlin Serialization 反序列化器的 [CustomEventResolver]。
+ * @since 1.8.0
+ * @author ForteScarlet
+ */
+@ExperimentalCustomEventResolverApi
+public fun interface CustomKotlinSerializationEventResolver : CustomEventResolver {
+
+    /**
+     * 根据 [context] 得到一个 [DeserializationStrategy]。
+     */
+    public fun serializer(context: CustomEventResolver.Context): DeserializationStrategy<Event>?
+
+    override fun resolve(context: CustomEventResolver.Context): Event? {
+        return serializer(context)?.let {
+            return context.json.decodeFromJsonElement(it, context.rawEventResolveResult.json)
+        }
+    }
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/EventResolveException.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/EventResolveException.kt
@@ -1,0 +1,14 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+/**
+ * 事件解析异常
+ *
+ * @since 1.8.0
+ * @author ForteScarlet
+ */
+public open class EventResolveException : RuntimeException {
+    public constructor() : super()
+    public constructor(cause: Throwable?) : super(cause)
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/ExperimentalCustomEventResolverApi.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/ExperimentalCustomEventResolverApi.kt
@@ -1,0 +1,14 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+/**
+ * 尚在实验中的自定义事件解析器API，可能在未来进行重大改动或被移除。
+ *
+ * @since 1.8.0
+ *
+ * @author ForteScarlet
+ */
+@RequiresOptIn(
+    "尚在实验中的自定义事件解析器API，可能在未来进行重大改动或被移除。",
+    RequiresOptIn.Level.WARNING,
+)
+public annotation class ExperimentalCustomEventResolverApi

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/RawEventResolveResult.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/RawEventResolveResult.kt
@@ -10,6 +10,7 @@ import love.forte.simbot.component.onebot.v11.event.RawEvent
  * @since 1.8.0
  * @author ForteScarlet
  */
+@ExperimentalCustomEventResolverApi
 public interface RawEventResolveResult {
     /**
      * 原始的事件JSON字符串文本。

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/RawEventResolveResult.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/core/event/RawEventResolveResult.kt
@@ -1,0 +1,65 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+import kotlinx.serialization.json.JsonObject
+import love.forte.simbot.common.id.LongID
+import love.forte.simbot.component.onebot.v11.event.RawEvent
+
+/**
+ * 一个原始事件文本被解析后的基本结果。
+ *
+ * @since 1.8.0
+ * @author ForteScarlet
+ */
+public interface RawEventResolveResult {
+    /**
+     * 原始的事件JSON字符串文本。
+     */
+    public val text: String
+
+    /**
+     * 经过解析后的 [JsonObject]。
+     */
+    public val json: JsonObject
+
+    /**
+     * [json] 的 `post_type` 属性。
+     * 在OneBot协议中这个属性的必须的，用于对事件进行首层分类。
+     */
+    public val postType: String
+
+    /**
+     * [json] 的 `sub_type` 属性。
+     * 在OneBot标准协议中这个属性始终存在，且获取它的 JSON KEY
+     * 等同于 `$postType_type`。
+     * 以标准事件为例子，
+     * ```json
+     * {
+     *   "post_type": "message",
+     *   "message_type": "private"
+     * }
+     * ```
+     * 当 `post_type` 为 `message` 时，`sub_type` 即代表 `message_type`，则其值为 `private`。
+     */
+    public val subType: String?
+
+    /**
+     * jsonObject 的 `time` 属性。
+     */
+    public val time: Long?
+
+    /**
+     * jsonObject 的 `self_id` 属性。是一个长整型ID。
+     */
+    public val selfId: LongID?
+
+    /**
+     * 如果能被标准事件类型成功解析，则此处为被解析出来的标准事件，否则为 `null`。
+     */
+    public val rawEvent: RawEvent?
+
+    /**
+     * 如果 [rawEvent] 是因为某些异常（例如序列化异常）才导致无法解析得到 `null` 的，
+     * 则此处为解析时的异常。
+     */
+    public val reason: Throwable?
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolverTests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolverTests.kt
@@ -77,6 +77,7 @@ class CustomEventResolverTests {
         }
     }
 
+    @OptIn(ExperimentalCustomEventResolverApi::class)
     @Test
     fun testCustomEventResolver() = runTest {
         val count = atomic(0)
@@ -115,6 +116,7 @@ class CustomEventResolverTests {
         assertEquals(1, count.value)
     }
 
+    @OptIn(ExperimentalCustomEventResolverApi::class)
     @Test
     fun testCustomEventResolverByKtxSerialization() = runTest {
         val count = atomic(0)

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolverTests.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-core/src/commonTest/kotlin/love/forte/simbot/component/onebot/v11/core/event/CustomEventResolverTests.kt
@@ -1,0 +1,148 @@
+package love.forte.simbot.component.onebot.v11.core.event
+
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import love.forte.simbot.annotations.ExperimentalSimbotAPI
+import love.forte.simbot.application.listeners
+import love.forte.simbot.common.atomic.atomic
+import love.forte.simbot.common.id.ID
+import love.forte.simbot.common.id.UUID
+import love.forte.simbot.common.time.Timestamp
+import love.forte.simbot.component.onebot.v11.core.bot.OneBotBot
+import love.forte.simbot.component.onebot.v11.core.bot.OneBotBotConfiguration
+import love.forte.simbot.component.onebot.v11.core.bot.addCustomKotlinSerializationEventResolver
+import love.forte.simbot.component.onebot.v11.core.bot.register
+import love.forte.simbot.component.onebot.v11.core.oneBot11Bots
+import love.forte.simbot.component.onebot.v11.core.useOneBot11
+import love.forte.simbot.core.application.launchSimpleApplication
+import love.forte.simbot.event.Event
+import love.forte.simbot.event.EventListenerRegistrar
+import love.forte.simbot.event.FuzzyEventTypeImplementation
+import love.forte.simbot.event.process
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ *
+ * @author ForteScarlet
+ */
+class CustomEventResolverTests {
+    /**
+     * postType: custom
+     *
+     * subType: test1
+     *
+     * ```json
+     * {
+     *   "post_type": "custom",
+     *   "custom_type": "test1",
+     *   "value": "test1"
+     * }
+     * ```
+     */
+    @OptIn(FuzzyEventTypeImplementation::class)
+    @Serializable
+    private data class CustomEvent1(
+        @SerialName("post_type")
+        val postType: String,
+        @SerialName("custom_type")
+        val customType: String,
+        val value: String
+    ) : Event {
+        override val id: ID = UUID.random()
+
+        @OptIn(ExperimentalSimbotAPI::class)
+        override val time: Timestamp = Timestamp.now()
+    }
+
+    private suspend inline fun bot(
+        eventHandle: EventListenerRegistrar.() -> Unit = {},
+        config: OneBotBotConfiguration.() -> Unit = {}
+    ): OneBotBot {
+        val app = launchSimpleApplication {
+            useOneBot11()
+        }
+
+        app.listeners {
+            eventHandle()
+        }
+
+        app.oneBot11Bots {
+            return register {
+                botUniqueId = UUID.random().toString()
+                config()
+            }
+        }
+    }
+
+    @Test
+    fun testCustomEventResolver() = runTest {
+        val count = atomic(0)
+
+        val bot = bot({
+            process<CustomEvent1> { event ->
+                assertEquals("custom", event.postType)
+                assertEquals("test1", event.customType)
+                assertEquals("Hello, World", event.value)
+                count.incrementAndGet()
+            }
+        }) {
+            addCustomEventResolver { context ->
+                val rawEventResolveResult = context.rawEventResolveResult
+                if (rawEventResolveResult.postType == "custom" && rawEventResolveResult.subType == "test1") {
+                    return@addCustomEventResolver context.json.decodeFromJsonElement(
+                        CustomEvent1.serializer(),
+                        rawEventResolveResult.json
+                    )
+                }
+
+                null
+            }
+        }
+
+        bot.push(
+            """
+            {
+              "post_type": "custom",
+              "custom_type": "test1",
+              "value": "Hello, World"
+            }
+        """.trimIndent()
+        ).collect()
+
+        assertEquals(1, count.value)
+    }
+
+    @Test
+    fun testCustomEventResolverByKtxSerialization() = runTest {
+        val count = atomic(0)
+
+        val bot = bot({
+            process<CustomEvent1> { event ->
+                assertEquals("custom", event.postType)
+                assertEquals("test1", event.customType)
+                assertEquals("Hello, World", event.value)
+                count.incrementAndGet()
+            }
+        }) {
+            addCustomKotlinSerializationEventResolver("custom", "test1") {
+                CustomEvent1.serializer()
+            }
+        }
+
+        bot.push(
+            """
+            {
+              "post_type": "custom",
+              "custom_type": "test1",
+              "value": "Hello, World"
+            }
+        """.trimIndent()
+        ).collect()
+
+        assertEquals(1, count.value)
+    }
+
+}

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/api/simbot-component-onebot-v11-event.api
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/api/simbot-component-onebot-v11-event.api
@@ -4,6 +4,13 @@ public abstract interface class love/forte/simbot/component/onebot/v11/event/Raw
 	public abstract fun getTime ()J
 }
 
+public class love/forte/simbot/component/onebot/v11/event/RawEventDeserializationException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Throwable;)V
+}
+
 public final class love/forte/simbot/component/onebot/v11/event/UnknownEvent : love/forte/simbot/component/onebot/v11/event/RawEvent {
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getPostType ()Ljava/lang/String;

--- a/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/RawEventDeserializationException.kt
+++ b/simbot-component-onebot-v11/simbot-component-onebot-v11-event/src/commonMain/kotlin/love/forte/simbot/component/onebot/v11/event/RawEventDeserializationException.kt
@@ -1,0 +1,14 @@
+package love.forte.simbot.component.onebot.v11.event
+
+/**
+ *
+ * [RawEvent] 的反序列化异常。
+ * @since 1.8.0
+ * @author ForteScarlet
+ */
+public open class RawEventDeserializationException : RuntimeException {
+    public constructor() : super()
+    public constructor(cause: Throwable?) : super(cause)
+    public constructor(message: String?) : super(message)
+    public constructor(message: String?, cause: Throwable?) : super(message, cause)
+}


### PR DESCRIPTION
OneBot协议中可能存在很多额外的、自定义的事件。

在配置中增加注册 `CustomEventResolver` 的配置项以支持对初步解析的事件进行处理，允许自定义事件解析。

假设自定义的事件是这样的：

```json
{
  "post_type": "custom",
  "custom_type": "test",
  "value": "test1"
}
```
那么注册解析器：

```kotlin
// 事件类型定义
    @OptIn(FuzzyEventTypeImplementation::class)
    @Serializable
   data class CustomEvent(
        @SerialName("post_type")
        val postType: String,
        @SerialName("custom_type")
        val customType: String,
        val value: String
    ) : Event {
        override val id: ID = UUID.random()

        @OptIn(ExperimentalSimbotAPI::class)
        override val time: Timestamp = Timestamp.now()
    }

////

botManager.register {
  // this: OneBotBotConfiguration
  // 添加一个自定义事件解析器
  addCustomEventResolver { context ->
      val rawEventResolveResult = context.rawEventResolveResult
      if (rawEventResolveResult.postType == "custom" && rawEventResolveResult.subType == "test") {
          return@addCustomEventResolver context.json.decodeFromJsonElement(
              CustomEvent.serializer(),
              rawEventResolveResult.json
          )
      }
      
      null // null 代表跳过
  }
    
    // 可以在实现了ktx序列化的情况下使用扩展函数：
    addCustomKotlinSerializationEventResolver("custom", "test") {
        CustomEvent.serializer()
    }
}
```

> [!note]
> `postType` 和 `subType` 要符合OneBot协议的一贯风格。即 `subType` 的 key 为 `${postType}_type`，以上述代码示例为例，当 `postType` = `custom` 时，`subType` 的 key 名称为 `custom_type`，此时 `subType` 的实际值为 `test`。

> [!warning]
> 相关API和类型处于实验阶段。

> [!warning]
> 自定义事件处理器优先级高于的 RawEvent 处理，因此当自定义事件处理器得到了结果，会覆盖原本默认的处理方案。

close #204